### PR TITLE
BCDA-1717: Set nav menu items to "active" based on the current page

### DIFF
--- a/_includes/global_nav.html
+++ b/_includes/global_nav.html
@@ -3,7 +3,8 @@
   {% for p in pages %}
       <div class="topdrop">
           <div class="dropdown">
-              <a class="topmenu" href="{{ p.url }}" aria-label="{{ item.title }}"> {{item.title}} </a>
+              {% assign prefix = page.id | split: "-" %}
+              <a class="topmenu{% if p.id contains prefix[0] || p.id == page.id %} active{% endif %}" href="{{ p.url }}" aria-label="{{ item.title }}"> {{item.title}} </a>
           </div>
       </div>
   {% endfor %}

--- a/assets/css/static-main.css
+++ b/assets/css/static-main.css
@@ -6206,6 +6206,19 @@ article h2::after {
     color: #339392;
 }
 
+@media only screen and (max-width: 1023px){
+  .topmenu {
+    padding: 8px 10px;
+    margin: 5px;
+  }
+  .topmenu:active,
+  .topmenu:focus,
+  .topmenu:hover,
+  .topmenu.active {
+    border-radius: 3px;
+  }
+}
+
 /*
 .submenu {
     color: #fff;

--- a/assets/css/static-main.css
+++ b/assets/css/static-main.css
@@ -6200,7 +6200,8 @@ article h2::after {
 
 .topmenu:active,
 .topmenu:focus,
-.topmenu:hover{
+.topmenu:hover,
+.topmenu.active {
     background-color: #fff;
     color: #339392;
 }


### PR DESCRIPTION
### Relates to [BCDA-1717](https://jira.cms.gov/browse/BCDA-1717)

### Change Details
- Set global nav menu items to "active" based on the page you are viewing. A minor UX improvement meant to indicate the page/section of the site you are currently on.

### Security Implications

These changes are related to the on-going initiative to move sandbox and production user guide documentation to a unified location. A security checklist has been completed to evaluate the implications of redirecting the sandbox user guide to the combined sandbox/prod user guide (linked below).

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [x] security checklist is completed for this change
  - See: https://confluence.cms.gov/pages/viewpage.action?pageId=154444934
- [ ] requires more information or team discussion to evaluate security implications

### Acceptance Validation

Please review by checking out this branch and running the site as described in the [README](https://github.com/CMSgov/bcda-static-site/blob/master/README.md).

Examples of the UI behavior:

**When viewing the home/landing page**

<img src="https://user-images.githubusercontent.com/72608/65069054-82b42a80-d94f-11e9-8c95-c0b457995795.png" width="350" />

**When viewing the Production "Getting Started" page**

<img src="https://user-images.githubusercontent.com/72608/65069091-9495cd80-d94f-11e9-9f06-7cca3b48d775.png" width="350" />

**When viewing the Production "Advanced User Guide" page**

<img src="https://user-images.githubusercontent.com/72608/65069128-ac6d5180-d94f-11e9-8c4d-ae9bbac48971.png" width="350" />