### PR TITLE
BCDA-2351: Automate Tag/Release Process for BCDA Static Site

### DIFF
--- a/ops/github_release.py
+++ b/ops/github_release.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
  
     parser.add_argument(
         '--repo', dest='repo', type=str,
-        help='The repository of the release (i.e., /repos/CMSgov/bcda-app/releases)'
+        help='The repository of the release (i.e., /repos/CMSgov/bcda-static-site/releases)'
     )
 
     args = parser.parse_args()

--- a/ops/github_release.py
+++ b/ops/github_release.py
@@ -1,0 +1,60 @@
+import argparse
+import json
+import os
+import sys
+import urllib.request
+
+
+def main(release, release_file, repo):
+    access_token = os.environ['GITHUB_ACCESS_TOKEN']
+
+    with open(release_file, 'r') as f:
+        data = {
+            "tag_name": release,
+            "name": release,
+            "body": f.read(),
+            "draft": False,
+            "prerelease": False
+        }
+
+        base_url = "https://api.github.com"
+        path = repo
+        headers = {
+            "Authorization": "token %s" % access_token
+        }
+
+        req = urllib.request.Request(
+            base_url + path, data=json.dumps(data).encode('utf-8'),
+            headers=headers,
+            method='POST'
+        )
+        resp = urllib.request.urlopen(req)
+
+    if resp.status != 201:
+        print("Could not create release: %s" % release)
+        sys.exit(1)
+    else:
+        print("Successfully created release: %s" % release)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        '--release', dest='release', type=str,
+        help='The version tag/identifier for the release'
+    )
+
+    parser.add_argument(
+        '--release-file', dest='release_file', type=str,
+        help='Path to file with body of release notes'
+    )
+ 
+    parser.add_argument(
+        '--repo', dest='repo', type=str,
+        help='The repository of the release (i.e., /repos/CMSgov/bcda-app/releases)'
+    )
+
+    args = parser.parse_args()
+
+    main(args.release, args.release_file, args.repo)

--- a/ops/release.sh
+++ b/ops/release.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+PROJECT_NAME="Beneficiary Claims Data API Static Site"
+
+usage() {
+    cat <<EOF >&2
+Start a new $PROJECT_NAME release.
+
+Usage: GITHUB_REPO_PATH=<gh_repo> GITHUB_ACCESS_TOKEN=<gh_access_token> $(basename "$0") [-ch] [-t previous-tag new-tag]
+
+Optionally, GITHUB_USER, GITHUB_EMAIL, and GITHUB_GPG_KEY_FILE environment variables can be set prior to running this script, to identify and verify who is creating the release.  This is primarily necessary when the release process is run from a Docker container (i.e., from Jenkins).
+
+Options:
+  -h    print this help text and exit
+  -t    manually specify tags
+EOF
+}
+
+MANUAL_TAGS=
+while getopts ":chtp" opt; do
+    case "$opt" in
+        t)
+            MANUAL_TAGS=1
+            ;;
+        h)
+            usage
+            exit 0
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            exit 1
+            ;;
+    esac
+done
+
+shift $((OPTIND-1))
+
+if [ $# -lt 2 ] && [ -n "$MANUAL_TAGS" ]
+then
+  usage
+  exit 1
+fi
+
+if [ -z "$(echo $(python -V) | grep "Python 3")" ]
+then
+  echo "Python 3+ is required"
+  exit 1
+fi
+
+if [ -z "$GITHUB_ACCESS_TOKEN" ]
+then
+  echo "Please export GITHUB_ACCESS_TOKEN to continue">&2
+  exit 1
+fi
+
+if [ -z "$GITHUB_REPO_PATH" ]
+then
+  echo "Please export GITHUB_REPO_PATH to continue (i.e., /CMSgov/bcda-app">&2
+  exit 1
+fi
+
+# initialize git configuration if env vars are set
+if [ ! -z "$GITHUB_USER" ] && [ ! -z "$GITHUB_EMAIL" ] && [ ! -z "$GITHUB_GPG_KEY_FILE" ]
+then
+  git config user.name "$GITHUB_USER"
+  git config user.email "$GITHUB_EMAIL"
+  gpg --import $GITHUB_GPG_KEY_FILE
+fi
+
+# fetch tags before any tag lookups so we have the most up-to-date list
+# and generate the correct next release number
+git fetch https://${GITHUB_ACCESS_TOKEN}@github.com$GITHUB_REPO_PATH --tags
+
+if [ -n "$MANUAL_TAGS" ]; then
+  PREVTAG="$1"
+  NEWTAG="$2"
+  PREVRELEASENUM=${PREVTAG//^r/}
+  NEWRELEASENUM=${NEWTAG//^r/}
+else
+  PREVTAG=$(git tag | sort -n | tail -1)
+  if [ ! -n "$PREVTAG" ]; then
+      PREVRELEASENUM=
+  else
+      PREVRELEASENUM=$(git tag | grep '^r[0-9]' | sed 's/^r//' | sort -n | tail -1)
+  fi
+  NEWRELEASENUM=$(($PREVRELEASENUM + 1))
+  PREVTAG="r$PREVRELEASENUM"
+  NEWTAG="r$NEWRELEASENUM"
+fi
+
+TMPFILE=$(mktemp /tmp/$(basename $0).XXXXXX) || exit 1
+
+if [ -n $PREVTAG ]
+then
+  commits=$(git log --pretty=format:"- %s" $PREVTAG..HEAD)
+else
+  commits=$(git log --pretty=format:"- %s" HEAD)
+fi
+
+echo "$NEWTAG - $(date +%Y-%m-%d)" > $TMPFILE
+echo "================" >> $TMPFILE
+echo "" >> $TMPFILE
+echo "$commits" >> $TMPFILE
+echo "" >> $TMPFILE
+
+git tag -a -m"$PROJECT_NAME release $NEWTAG" -s "$NEWTAG"
+
+RELEASE_PATH="/repos$GITHUB_REPO_PATH/releases"
+python github_release.py --release $NEWTAG --release-file $TMPFILE --repo $RELEASE_PATH
+
+rm $TMPFILE
+
+echo "Release $NEWTAG created."
+echo


### PR DESCRIPTION
### Fixes [BCDA-2351](https://jira.cms.gov/browse/BCDA-2351)

Allow tag/release process to be executed from Jenkins job in an automated fashion.

### Change Details

- Migrated to this repository existing scripts (used by BCDA and SSAS) for tagging/releasing BCDA static site repository.   Note: all code in this PR has been vetted through tag/release process of BCDA and SSAS.
- Jenkins job developed as part of [this PR](https://github.com/CMSgov/bcda-ops/pull/358).

### Security Implications

PII/PHI is not involved in this process.  This is simply automation for tagging in Github.

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

### Acceptance Validation

Jenkins job can be [viewed here](https://bcda-ci.adhocteam.us/job/BCDA%20-%20Tag%20and%20Release%20-%20Static%20Site/).

Several releases created for `bcda-static-site`.  See screenshot below. (Note: all temporary tags and releases have since been removed).

<img width="833" alt="Screen Shot 2019-11-21 at 9 33 37 PM" src="https://user-images.githubusercontent.com/37818548/69393926-83976e80-0ca8-11ea-97c3-9b54c262c703.png">


### Feedback Requested

Please review.
