### PR TITLE
Specify that we provide 5 sets of synthetic credentials.

### DIFF
--- a/sandbox/user_guide.md
+++ b/sandbox/user_guide.md
@@ -46,7 +46,7 @@ Once the page is open, your first step will be getting an **access token**.  You
 
 In the sandbox environment, we provide generic credentials for you to use. These will not work in the production environment, but will allow you to explore the synthetic data in sandbox.
 
-We have provided four sets of synthetic credentials for use in the sandbox, corresponding to various amounts of synthetic beneficiaries. We suggest testing with the credentials that most closely align with the size of your ACO, so that you can get a feel for working with a similar amount of synthetic data to that which you’ll receive in production.
+We have provided five sets of synthetic credentials for use in the sandbox, corresponding to various amounts of synthetic beneficiaries. We suggest testing with the credentials that most closely align with the size of your ACO, so that you can get a feel for working with a similar amount of synthetic data to that which you’ll receive in production.
 
 <button class="accordion"> Extra-Small ACO (50 synthetic beneficiaries) </button>
 <div class="acc_content">


### PR DESCRIPTION
We indicate that we provide four sets of synthetic credentials, but we actually provide five sets.

### Change Details

Fixed the trivial typo.

### Security Implications

No security implications with this change.

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

### Acceptance Validation

Tested locally.

### Feedback Requested

Please review.
