### PR TITLE
BCDA-2501 Update cURL examples to work with Akamai

### DIFF
--- a/production/technical_userguide.md
+++ b/production/technical_userguide.md
@@ -70,7 +70,7 @@ Client Secret:
 In the following cURL command, notice that we have concatenated the base64 encoding of the 'Client ID":" Client Secret' as the argument to the -H flag.
 
 ```
-curl -X POST "https://api.bcda.cms.gov/auth/token" -H "accept: application/json" -H "authorization: Basic MDk4NjlhN2YtNDZjZS00OTA4LWE5MTQtNjEyOWQwODBhMmFlOjY0OTE2ZmU5NmY3MWFkYzc5YzU3MzVlNDlmNGU3MmYxOGZmOTQxZDBkZDYyY2Y0M2VlMWFlMDg1N2UyMDRmMTczYmExMGU0MjUwYzEyYzQ4"
+curl -d '' -X POST "https://api.bcda.cms.gov/auth/token" -H "accept: application/json" -H "authorization: Basic MDk4NjlhN2YtNDZjZS00OTA4LWE5MTQtNjEyOWQwODBhMmFlOjY0OTE2ZmU5NmY3MWFkYzc5YzU3MzVlNDlmNGU3MmYxOGZmOTQxZDBkZDYyY2Y0M2VlMWFlMDg1N2UyMDRmMTczYmExMGU0MjUwYzEyYzQ4"
 ```
 
 **Response**

--- a/sandbox/technical_user_guide.md
+++ b/sandbox/technical_user_guide.md
@@ -139,7 +139,7 @@ Basic Mzg0MWM1OTQtYThjMC00MWU1LTk4Y2MtMzhiYjQ1MzYwZDNjOmY5NzgwZDMyMzU4OGYxY2RmYz
 **cURL command**
 
 ```
-curl -X POST "https://sandbox.bcda.cms.gov/auth/token" -H "accept: application/json" -H "authorization: Basic Mzg0MWM1OTQtYThjMC00MWU1LTk4Y2MtMzhiYjQ1MzYwZDNjOm\
+curl -d '' -X POST "https://sandbox.bcda.cms.gov/auth/token" -H "accept: application/json" -H "authorization: Basic Mzg0MWM1OTQtYThjMC00MWU1LTk4Y2MtMzhiYjQ1MzYwZDNjOm\
 Y5NzgwZDMyMzU4OGYxY2RmYzNlNjNlOTVhOGNiZGNkZDQ3NjAy\
 ZmY0OGE1MzdiNTFkYzVkNzgzNGJmNDY2NDE2YTcxNmJkNDUwOGU5MDRh"
 ```


### PR DESCRIPTION
### Fixes [BCDA-2501](https://jira.cms.gov/browse/BCDA-2501)
Since introducing Akamai, our cURL examples using Basic authentication no longer work.  This affects the `POST /auth/token` endpoint.  To fix this, we need to add an empty body by using a `-d ''` parameter.

### Proposed Changes
- Add a `-d ''` parameter to curl

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

This change should not affect the security stance of the application, its documentation, or its users.  Note that the screenshots below depict public credentials in the sandbox environment.

### Acceptance Validation
#### Unsuccessful request
<img width="855" alt="Unsuccessful request" src="https://user-images.githubusercontent.com/2533561/71228590-86d64800-22b0-11ea-8579-543666ddeb9a.png">

#### Successful request with `-d ''`
<img width="855" alt="Successful request with `-d ''`" src="https://user-images.githubusercontent.com/2533561/71228591-86d64800-22b0-11ea-8dba-0967aa54c15b.png">

#### Documentation example
<img width="602" alt="Documentation example" src="https://user-images.githubusercontent.com/2533561/71228589-86d64800-22b0-11ea-9b1e-6fee482a5c40.png">

### Feedback Requested
- Does any description of the change need to be added to the documentation?
- Would a different order of parameters be more clear?
