### PR TITLE
BCDA-2300 Accessibility: Change second <header> to <div>

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 <div class="ds-base">
-  <header class="blueberry-lime-gradient-background main-header ds-u-margin-bottom--2 ds-u-lg-margin-bottom--5">
+  <div class="blueberry-lime-gradient-background main-header ds-u-margin-bottom--2 ds-u-lg-margin-bottom--5">
     <div class="api-pattern">
       <div class="">
         <div class="ds-l-container">
@@ -18,7 +18,7 @@ layout: default
           </div>
         </div>
       </div>
-  </header>
+  </div>
 </div>
 
 <section class="ds-l-container ds-base">


### PR DESCRIPTION
### Fixes [BCDA-2300](https://jira.cms.gov/browse/BCDA-2300)
We have two `<header>` elements, which violates [best practice](https://dequeuniversity.com/rules/axe/3.3/landmark-no-duplicate-banner) for accessibility.

### Proposed Changes
Change the second `<header>` to a `<div>`

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

This invisible change should have no security impact.

### Acceptance Validation
#### Title header bar appears unaffected by change
![Screen Shot 2019-12-30 at 11 51 37 AM](https://user-images.githubusercontent.com/2533561/71591661-2ab6c380-2afb-11ea-801c-815bc521d5d4.png)

### Feedback Requested
Would we rather fold the second `<header>` into the first (see ticket for option details)?