### PR TITLE
BCDA-2303 Accessibility: Follow <nav> best practices

### DIFF
--- a/_includes/global_nav.html
+++ b/_includes/global_nav.html
@@ -1,11 +1,11 @@
 {% for item in site.global_nav %}
 {% assign pages = site.pages | where:"id",item.id %}
   {% for p in pages %}
-      <div class="topdrop">
+      <nav aria-label="Primary" class="topdrop">
           <div class="dropdown">
               {% assign prefix = page.id | split: "-" %}
               <a class="topmenu{% if p.id contains prefix[0] || p.id == page.id %} active{% endif %}" href="{{ p.url }}" aria-label="{{ item.title }}"> {{item.title}} </a>
           </div>
-      </div>
+      </nav>
   {% endfor %}
 {% endfor %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -13,7 +13,7 @@
       </div>
     </a>
     <!-- Desktop navigation -->
-    <nav class="desktop-nav-items">
+    <nav aria-label="Secondary" class="desktop-nav-items">
       <!-- removing for now
       <a href="{{ '/api/v1/swagger' }}">Documentation</a>
       -->
@@ -39,7 +39,7 @@
     </a>
   </div>
   <!-- Mobile Nav Items -->
-  <nav class="mobile-nav-items">
+  <nav aria-label="Secondary" class="mobile-nav-items">
     <!-- Items Appended Here by JS -->
   </nav>
 </header>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -24,7 +24,7 @@ layout: default
 <section class="ds-l-container ds-base">
   <div class="ds-l-row">
     <aside class="ds-l-col--4 ds-u-margin-left--right ds-u-display--none ds-u-sm-display--block" role="complementary">
-      <nav class="subnav">
+      <nav aria-label="Page" class="subnav">
         <h5 class="sr-only" id="page-sub-nav">Page navigation links</h5>
         <ul class="ds-c-list ds-c-list--bare" id="mainNav" aria-labelledby="page-sub-nav">
           {% for item in page.sections %}


### PR DESCRIPTION
### Fixes [BCDA-2303](https://jira.cms.gov/browse/BCDA-2303)
Ideally, navigation elements should be labeled.

### Proposed Changes
- Add an `aria-label` (Primary, Secondary, or Page) to each navigation section
- Change `<div>` to `<nav>` for page navigation

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

The addition of these largely invisible labels should have no security impact.

### Acceptance Validation
#### No visual or behavior change to navigation 
![Screen Shot 2019-12-30 at 1 38 44 PM](https://user-images.githubusercontent.com/2533561/71595448-bafc0500-2b09-11ea-8f0a-1d42045807ac.png)

### Feedback Requested
Would it be better to have a single `<nav>` around the page navigation section?