### PR TITLE
BCDA-2299 Accessibility: Avoid skipping heading levels (footer)

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,7 +8,7 @@
         A federal government website managed by the Centers for Medicare &amp; Medicaid Services 7500 Security Boulevard, Baltimore, MD 21124
       </div>
       <div class="ds-l-col--12 ds-l-sm-col--6 ds-l-md-col--3 ds-u-margin-bottom--2">
-        <h6 class="ds-h4">CMS &amp; HHS Websites</h6>
+        <h2 class="ds-h4">CMS &amp; HHS Websites</h2>
         <ul class="ds-c-list ds-c-list--bare ds-u-font-size--small">
           <li><a target="_blank" href="https://www.cms.gov/">CMS.gov</a></li>
           <li><a target="_blank" href="https://www.medicare.gov/">Medicare.gov</a></li>
@@ -19,7 +19,7 @@
         </ul>
       </div>
       <div class="ds-l-col--12 ds-l-sm-col--6 ds-l-md-col--3 ds-u-margin-bottom--2">
-        <h6 class="ds-h4">Additional resources</h6>
+        <h2 class="ds-h4">Additional resources</h2>
         <ul class="ds-c-list ds-c-list--bare ds-u-font-size--small">
           <li><a target="_blank" href="https://standards.usa.gov/">U.S. Web Design Standards</a></li>
           <li><a target="_blank" href="https://www.foia.gov/">Freedom of Information Act</a></li>


### PR DESCRIPTION
### Fixes [BCDA-2299](https://jira.cms.gov/browse/BCDA-2299)
Screen readers don't like heading levels to be skipped.  We can adjust our footer to that best practice without visible change.

### Proposed Changes
- Change footer headings to `<h2>`

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

No data has been exposed in this documentation change.

### Acceptance Validation
#### No visible change in footer ("CMS & HHS Websites" and "Additional resources")
![Screen Shot 2019-12-30 at 3 53 56 PM](https://user-images.githubusercontent.com/2533561/71600420-ce649b80-2b1c-11ea-9d1a-e38d6b116a7a.png)

### Feedback Requested
Any concerns?