### PR TITLE
BCDA-2304 Accessibility: Remove aria-label on top menu

### DIFF
--- a/_includes/global_nav.html
+++ b/_includes/global_nav.html
@@ -4,7 +4,7 @@
       <nav aria-label="Primary" class="topdrop">
           <div class="dropdown">
               {% assign prefix = page.id | split: "-" %}
-              <a class="topmenu{% if p.id contains prefix[0] || p.id == page.id %} active{% endif %}" href="{{ p.url }}" aria-label="{{ item.title }}"> {{item.title}} </a>
+              <a class="topmenu{% if p.id contains prefix[0] || p.id == page.id %} active{% endif %}" href="{{ p.url }}"> {{item.title}} </a>
           </div>
       </nav>
   {% endfor %}


### PR DESCRIPTION
### Fixes [BCDA-2304](https://jira.cms.gov/browse/BCDA-2304)
The text in the `aria-label` provided with the top menu items duplicates the link text.  This is repetitive for assistive technology.

### Proposed Changes
Remove `aria-label` tags on the top menu.

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

No data has been exposed in this documentation change.

### Acceptance Validation
#### Before (includes `aria-label`)
![Screen Shot 2020-01-27 at 1 54 04 PM](https://user-images.githubusercontent.com/2533561/73204563-2f2bc780-410d-11ea-8de6-afa33d68cb8c.png)

#### After
![Screen Shot 2020-01-27 at 1 53 15 PM](https://user-images.githubusercontent.com/2533561/73204623-45d21e80-410d-11ea-9716-9766c55922ea.png)

#### No visible change
![Screen Shot 2020-01-27 at 1 52 53 PM](https://user-images.githubusercontent.com/2533561/73204636-4a96d280-410d-11ea-9afd-489c70274f57.png)

### Feedback Requested
Is there any other code or configuration that affects the top menu items?