### PR TITLE
BCDA-2305 Accessibility: Menu uses a list

### DIFF
--- a/_includes/global_nav.html
+++ b/_includes/global_nav.html
@@ -1,13 +1,13 @@
-{% for item in site.global_nav %}
-{% assign pages = site.pages | where:"id",item.id %}
-<ul class="dropdown">
-  {% for p in pages %}
-    <li class="no_list">
-      <nav aria-label="Primary" class="topdrop">
-              {% assign prefix = page.id | split: "-" %}
-              <a class="topmenu{% if p.id contains prefix[0] || p.id == page.id %} active{% endif %}" href="{{ p.url }}" aria-label="{{ item.title }}"> {{item.title}} </a>
-      </nav>
-    </li>
-  {% endfor %}
-</ul>
-{% endfor %}
+<nav aria-label="Primary" class="topdrop">
+    <ul class="slim_ul">
+        {% for item in site.global_nav %}
+            {% assign pages = site.pages | where:"id",item.id %}
+            {% for p in pages %}
+                <li class="dropdown">
+                    {% assign prefix = page.id | split: "-" %}
+                    <a class="topmenu{% if p.id contains prefix[0] || p.id == page.id %} active{% endif %}" href="{{ p.url }}" aria-label="{{ item.title }}"> {{item.title}} </a>
+                </li>
+            {% endfor %}
+        {% endfor %}
+    </ul>
+</nav>

--- a/_includes/global_nav.html
+++ b/_includes/global_nav.html
@@ -1,11 +1,13 @@
 {% for item in site.global_nav %}
 {% assign pages = site.pages | where:"id",item.id %}
+<ul class="dropdown">
   {% for p in pages %}
+    <li class="no_list">
       <nav aria-label="Primary" class="topdrop">
-          <div class="dropdown">
               {% assign prefix = page.id | split: "-" %}
               <a class="topmenu{% if p.id contains prefix[0] || p.id == page.id %} active{% endif %}" href="{{ p.url }}" aria-label="{{ item.title }}"> {{item.title}} </a>
-          </div>
       </nav>
+    </li>
   {% endfor %}
+</ul>
 {% endfor %}

--- a/assets/css/static-main.css
+++ b/assets/css/static-main.css
@@ -6285,3 +6285,9 @@ article h2::after {
 .accordion_active:after {
     content: "\2796";
 }
+
+.slim_ul {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+}


### PR DESCRIPTION
### Fixes [BCDA-2305](https://jira.cms.gov/browse/BCDA-2305)
The top menu currently uses `<div>` elements, but should have `<ul>`.

### Proposed Changes
- Move currently duplicated `<nav>` tag to wrap around entire top menu
- Add list elements and required CSS to mimic previous behavior

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

No data has been exposed in this documentation change.

### Acceptance Validation
#### Before
![BCDA top menu](https://user-images.githubusercontent.com/2533561/73224173-9f9b0e80-4136-11ea-8709-a8f2d79d0086.gif)

#### After
![BCDA top menu (after)](https://user-images.githubusercontent.com/2533561/73224180-a3c72c00-4136-11ea-9e94-67369c5d7f0a.gif)

### Feedback Requested
- Is there a better CSS class name for this purpose?
- Is there a better way to accomplish this?
- Is the slightly wider space between menu items acceptable?