### PR TITLE
BCDA-2306 Accessibility: Mobile menu button

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -33,10 +33,10 @@
       </div>
     </a>
     <!-- Mobile Nav Trigger Button -->
-    <a class="mobile-nav-trigger-button" href="#">
+    <button class="mobile-nav-trigger-button" href="#">
       <span class="mobile-nav-trigger-text">Menu</span>
       <i class="mobile-nav-icon" data-feather="menu"></i>
-    </a>
+    </button>
   </div>
   <!-- Mobile Nav Items -->
   <nav aria-label="Secondary" class="mobile-nav-items">


### PR DESCRIPTION
### Fixes [BCDA-2306](https://jira.cms.gov/browse/BCDA-2306)
The mobile menu should be activated with a `<button>`, not the current anchor link.

### Proposed Changes
- Change the tag

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

No data has been exposed in this documentation change.

### Acceptance Validation
#### Before
![BCDA mobile menu (before)](https://user-images.githubusercontent.com/2533561/73225078-69ab5980-4139-11ea-9ade-0681207cd855.gif)

#### After
![BCDA mobile menu (after)](https://user-images.githubusercontent.com/2533561/73225083-6ca64a00-4139-11ea-9cf2-fa4f294f8e2a.gif)

### Feedback Requested
- Note that the blue highlight at the left of the selected button is new, but may be preferred for accessibility.  Do you disagree?
