### PR TITLE
BCDA-2307 Accessibility: Replace <aside> with <div>

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -23,7 +23,7 @@ layout: default
 
 <section class="ds-l-container ds-base">
   <div class="ds-l-row">
-    <aside class="ds-l-col--4 ds-u-margin-left--right ds-u-display--none ds-u-sm-display--block" role="complementary">
+    <div class="ds-l-col--4 ds-u-margin-left--right ds-u-display--none ds-u-sm-display--block" role="complementary">
       <nav aria-label="Page" class="subnav">
         <ul class="ds-c-list ds-c-list--bare" id="mainNav" aria-labelledby="page-sub-nav">
           {% for item in page.sections %}
@@ -31,7 +31,7 @@ layout: default
           {% endfor %}
         </ul>
       </nav>
-    </aside>
+    </div>
 
 
     <article class="ds-l-col--12 ds-l-sm-col--7 {{ page.badge | slugify }}" id="main" role="main">


### PR DESCRIPTION
### Fixes [BCDA-2307](https://jira.cms.gov/browse/BCDA-2307)
The submenu at the left of the page is too important to get an `<aside>` tag.

### Proposed Changes
- Replace with a `<div>` tag

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

No data has been exposed in this documentation change.

### Acceptance Validation
![Screen Shot 2020-01-27 at 7 27 27 PM](https://user-images.githubusercontent.com/2533561/73225656-6d3fe000-413b-11ea-99b1-44174b080677.png)

### Feedback Requested
- Any suggestions welcome