### PR TITLE
BCDA-2308 Accessibility: Remove contentinfo role in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,4 @@
-<footer class="ds-base ds-u-fill--white ds-u-margin-top--7 ds-u-padding-y--6" role="contentinfo">
+<footer class="ds-base ds-u-fill--white ds-u-margin-top--7 ds-u-padding-y--6">
   <div class="ds-l-container">
     <div class="ds-l-row">
       <div class="ds-u-font-size--small ds-l-col--12 ds-l-sm-col--6 ds-l-md-col--6 ds-u-margin-bottom--2">


### PR DESCRIPTION
### Fixes [BCDA-2308](https://jira.cms.gov/browse/BCDA-2308)
Explicitly setting the footer to the `contentinfo` role is redundant, as assistive technology will set it automatically.

### Proposed Changes
- Remove the `contentinfo` role in the footer

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

No data has been exposed in this documentation change.

### Acceptance Validation
![Screen Shot 2020-01-27 at 7 33 18 PM](https://user-images.githubusercontent.com/2533561/73225948-5bab0800-413c-11ea-807f-71b40677b140.png)

### Feedback Requested
- Any suggestions?