### PR TITLE
BCDA-2722: update user guide language around Bearer token

### DIFF
--- a/production/user_guide.md
+++ b/production/user_guide.md
@@ -82,7 +82,7 @@ Now that you have a token, you can tell Swagger to use it for your future reques
 In the "Value" box:
 
 * **First, you must type the word _Bearer_ followed by a space into the box. _Bearer_ is case-sensitive.**
-  * Failure to do this will result in a _401 Unauthorized_ error. 
+  * Failure to do this will result in an `HTTP 401 Unauthorized` error. 
 * Paste your token after the space following **_Bearer_**
 * Click "Authorize" and then "Close"
 

--- a/production/user_guide.md
+++ b/production/user_guide.md
@@ -81,8 +81,9 @@ Now that you have a token, you can tell Swagger to use it for your future reques
 
 In the "Value" box:
 
-* **Type the word "Bearer" followed by a space** (This step is critical!)
-* Paste your token
+* **First, you must type the word _Bearer_ followed by a space into the box. _Bearer_ is case-sensitive.**
+  * Failure to do this will result in a _401 Unauthorized_ error. 
+* Paste your token after the space following **_Bearer_**
 * Click "Authorize" and then "Close"
 
 <img class="ug-img" src="/assets/img/nav_swag_07.png" alt="Swagger: Authorizing with token"/>

--- a/sandbox/user_guide.md
+++ b/sandbox/user_guide.md
@@ -165,8 +165,9 @@ Now that you have a token, you can tell Swagger to use it for your future reques
 
 In the "Value" box:
 
-* **Type the word "Bearer" followed by a space** (This is critical!)
-* Paste your token
+* **First, you must type the word _Bearer_ followed by a space into the box. _Bearer_ is case-sensitive.**
+  * Failure to do this will result in a _401 Unauthorized_ error. 
+* Paste your token after the space following **_Bearer_**
 * Click "Authorize" and then "Close"
 
 <img class="ug-img" src="/assets/img/nav_swag_07.png" alt="Swagger: Authorizing with token"/>

--- a/sandbox/user_guide.md
+++ b/sandbox/user_guide.md
@@ -166,7 +166,7 @@ Now that you have a token, you can tell Swagger to use it for your future reques
 In the "Value" box:
 
 * **First, you must type the word _Bearer_ followed by a space into the box. _Bearer_ is case-sensitive.**
-  * Failure to do this will result in a _401 Unauthorized_ error. 
+  * Failure to do this will result in an `HTTP 401 Unauthorized` error. 
 * Paste your token after the space following **_Bearer_**
 * Click "Authorize" and then "Close"
 


### PR DESCRIPTION
Update to user guide language around Bearer token in swagger

### Fixes [BCDA-2722](https://jira.cms.gov/browse/BCDA-2722)

Users have been pasting in tokens to the Value box in Swagger's authorization window without "Bearer " appended in front of them. This PR, along with those that fix BCDA-2716 and BCDA-2717, is the first attempt at applying content strategy to call attention to this requirement.

### Proposed Changes

* Call out more clearly that Bearer is case-sensitive and must be followed by a space
* Describe error that will result if step is done incorrectly

### Change Details

Current state:
<img width="601" alt="Screen Shot 2020-02-12 at 12 08 38 PM" src="https://user-images.githubusercontent.com/28760377/74359039-83cb7580-4d90-11ea-80fa-154148ead5a0.png">

* We say "this is critical!" without specifying what "this" is
* No description of resultant error

PR state:
<img width="1124" alt="Screen Shot 2020-02-12 at 11 59 22 AM" src="https://user-images.githubusercontent.com/28760377/74359086-9a71cc80-4d90-11ea-834a-d12cb69a00a8.png">

* Provides answers to questions we have seen users have in onboarding sessions (case-sensitivity, need for space)
* Describes resultant error and allows for search/skim behavior for users to find the most likely cause when they receive a 401 unauthorized error. 


### Security Implications

None; language changes only.

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications


### Feedback Requested

* Is this language clearer than the current state?
* Are there other changes that would be helpful?