### PR TITLE
BCDA-2312 Accessibility: Do not duplicate credential elements

### DIFF
--- a/_includes/copy_snippet.md
+++ b/_includes/copy_snippet.md
@@ -1,10 +1,8 @@
 {% assign code = include.code %}
 
-<div class="highlight"><pre class="highlight"><code>{{code}}
-</code></pre></div>
-
 {% assign nanosecond = "now" | date: "%N" %}
-<input type="text" id="code{{ nanosecond }}" style="position: absolute;left: -1000px;" value="{{ code }}"/>
+<div class="highlight"><pre class="highlight"><code id="code{{ nanosecond }}">{{code}}</code></pre></div>
+
 <div class="button" on>
     <p>
         <a href="javascript:void(0)" onclick="copyText{{ nanosecond }}()" id="copybutton{{ nanosecond }}">
@@ -15,13 +13,11 @@
 
 <script>
 function copyText{{ nanosecond }}(){
-  /* Get the text field */
-  var copyText = document.getElementById("code{{ nanosecond }}");
-
-  /* Select the text field */
-  copyText.select();
-
-  /* Copy the text inside the text field */
-  document.execCommand("copy");
+  var range = document.createRange();
+  range.selectNode(document.getElementById("code{{ nanosecond }}"));    // find element
+  window.getSelection().removeAllRanges();                              // clear current selection
+  window.getSelection().addRange(range);                                // select text
+  document.execCommand("copy");                                         // copy text
+  window.getSelection().removeAllRanges();                              // deselect
 }
 </script>

--- a/sandbox/user_guide.md
+++ b/sandbox/user_guide.md
@@ -50,105 +50,85 @@ We have provided five sets of synthetic credentials for use in the sandbox, corr
 
 <button class="accordion"> Extra-Small ACO (50 synthetic beneficiaries) </button>
 <div class="acc_content">
-<label>
 Client ID:
 {%- capture client_id -%}
 3841c594-a8c0-41e5-98cc-38bb45360d3c
 {%- endcapture -%}
-</label>
 
 {% include copy_snippet.md code=client_id %}
 
-<label>
 Client Secret:
 {%- capture client_secret -%}
 f9780d323588f1cdfc3e63e95a8cbdcdd47602ff48a537b51dc5d7834bf466416a716bd4508e904a
 {%- endcapture -%}
-</label>
 
 {% include copy_snippet.md code=client_secret %}
 </div>
 
 <button class="accordion"> Small ACO (2,500 synthetic beneficiaries) </button>
 <div class="acc_content">
-<label>
 Client ID:
 {%- capture client_id -%}
 d5f83f74-6c55-4f1e-9d16-0022688171ba
 {%- endcapture -%}
-</label>
 
 {% include copy_snippet.md code=client_id %}
 
-<label>
 Client Secret:
 {%- capture client_secret -%}
 01c23cf3f31f82a5c2dcef5136a8eaa32959158351f4e28aaec5fc6550cb2a5b5d112c5b8aacc434
 {%- endcapture -%}
-</label>
 
 {% include copy_snippet.md code=client_secret %}
 </div>
 
 <button class="accordion"> Medium ACO (7,500 synthetic beneficiaries) </button>
 <div class="acc_content">
-<label>
 Client ID:
 {%- capture client_id -%}
 8c75a6f6-02b9-4a47-96c1-0bd6efd4b5e3
 {%- endcapture -%}
-</label>
 
 {% include copy_snippet.md code=client_id %}
 
-<label>
 Client Secret:
 {%- capture client_secret -%}
 e1c920141c4aca6b8f726fa8aa0f7b55e095fd1ea3368a5f24b3636fdc907f113d6677977c7259dd
 {%- endcapture -%}
-</label>
 
 {% include copy_snippet.md code=client_secret %}
 </div>
 
 <button class="accordion"> Large ACO (20,000 synthetic beneficiaries) </button>
 <div class="acc_content">
-<label>
 Client ID:
 {%- capture client_id -%}
 f268a8c6-8a29-4d2b-8b92-263dc775750d
 {%- endcapture -%}
-</label>
 
 {% include copy_snippet.md code=client_id %}
 
-<label>
 Client Secret:
 {%- capture client_secret -%}
 78ed083ad8e49475f36d04153649012b92c363a538ac97beaf0f7900403989581fc35324baa31e36
 {%- endcapture -%}
-</label>
 
 {% include copy_snippet.md code=client_secret %}
 </div>
 
 <button class="accordion"> Extra-Large ACO (30,000 synthetic beneficiaries) </button>
 <div class="acc_content">
-<label>
 Client ID:
 {%- capture client_id -%}
 6152afb4-c555-46e4-93de-fa16a441d643
 {%- endcapture -%}
-</label>
 
 {% include copy_snippet.md code=client_id %}
 
-<label>
 Client Secret:
 {%- capture client_secret -%}
 1ace5a0e9fdf0c3d713e8c029269eacd024732ccd59e2cf283374e0f8dc93b34429d71b77e55b9a2
 {%- endcapture -%}
-</label>
 
 {% include copy_snippet.md code=client_secret %}
 </div>

--- a/sandbox/user_guide.md
+++ b/sandbox/user_guide.md
@@ -50,85 +50,105 @@ We have provided five sets of synthetic credentials for use in the sandbox, corr
 
 <button class="accordion"> Extra-Small ACO (50 synthetic beneficiaries) </button>
 <div class="acc_content">
+<label>
 Client ID:
 {%- capture client_id -%}
 3841c594-a8c0-41e5-98cc-38bb45360d3c
 {%- endcapture -%}
+</label>
 
 {% include copy_snippet.md code=client_id %}
 
+<label>
 Client Secret:
 {%- capture client_secret -%}
 f9780d323588f1cdfc3e63e95a8cbdcdd47602ff48a537b51dc5d7834bf466416a716bd4508e904a
 {%- endcapture -%}
+</label>
 
 {% include copy_snippet.md code=client_secret %}
 </div>
 
 <button class="accordion"> Small ACO (2,500 synthetic beneficiaries) </button>
 <div class="acc_content">
+<label>
 Client ID:
 {%- capture client_id -%}
 d5f83f74-6c55-4f1e-9d16-0022688171ba
 {%- endcapture -%}
+</label>
 
 {% include copy_snippet.md code=client_id %}
 
+<label>
 Client Secret:
 {%- capture client_secret -%}
 01c23cf3f31f82a5c2dcef5136a8eaa32959158351f4e28aaec5fc6550cb2a5b5d112c5b8aacc434
 {%- endcapture -%}
+</label>
 
 {% include copy_snippet.md code=client_secret %}
 </div>
 
 <button class="accordion"> Medium ACO (7,500 synthetic beneficiaries) </button>
 <div class="acc_content">
+<label>
 Client ID:
 {%- capture client_id -%}
 8c75a6f6-02b9-4a47-96c1-0bd6efd4b5e3
 {%- endcapture -%}
+</label>
 
 {% include copy_snippet.md code=client_id %}
 
+<label>
 Client Secret:
 {%- capture client_secret -%}
 e1c920141c4aca6b8f726fa8aa0f7b55e095fd1ea3368a5f24b3636fdc907f113d6677977c7259dd
 {%- endcapture -%}
+</label>
 
 {% include copy_snippet.md code=client_secret %}
 </div>
 
 <button class="accordion"> Large ACO (20,000 synthetic beneficiaries) </button>
 <div class="acc_content">
+<label>
 Client ID:
 {%- capture client_id -%}
 f268a8c6-8a29-4d2b-8b92-263dc775750d
 {%- endcapture -%}
+</label>
 
 {% include copy_snippet.md code=client_id %}
 
+<label>
 Client Secret:
 {%- capture client_secret -%}
 78ed083ad8e49475f36d04153649012b92c363a538ac97beaf0f7900403989581fc35324baa31e36
 {%- endcapture -%}
+</label>
 
 {% include copy_snippet.md code=client_secret %}
 </div>
 
 <button class="accordion"> Extra-Large ACO (30,000 synthetic beneficiaries) </button>
 <div class="acc_content">
+<label>
 Client ID:
 {%- capture client_id -%}
 6152afb4-c555-46e4-93de-fa16a441d643
 {%- endcapture -%}
+</label>
 
 {% include copy_snippet.md code=client_id %}
 
+<label>
 Client Secret:
 {%- capture client_secret -%}
 1ace5a0e9fdf0c3d713e8c029269eacd024732ccd59e2cf283374e0f8dc93b34429d71b77e55b9a2
 {%- endcapture -%}
+</label>
 
 {% include copy_snippet.md code=client_secret %}
 </div>


### PR DESCRIPTION
### Fixes [BCDA-2312](https://jira.cms.gov/browse/BCDA-2312)
Our nifty button to copy client ID's/secrets from the user guide has an accessibility flaw: it has a hidden duplicate input element, to make copying easier.

This PR does away with the input element, and thus the duplication, accepting the challenge goal of the ticket and sidestepping the original request (to add `<label>` tags for the input).

### Proposed Changes
- Change the `copyText()` function to not need an input element

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

The Javascript function touches security credentials, albeit publicly published credentials.  However, there is no effective change in security posture with the script changes.

### Acceptance Validation
![BCDA copy script](https://user-images.githubusercontent.com/2533561/75003572-3ad18c00-5436-11ea-90ab-42d248e14801.gif)

### Feedback Requested
Please try this in multiple browsers!
