### PR TITLE
BCDA-2318 Accessibility: Wrap long URL's

### DIFF
--- a/assets/css/static-main.css
+++ b/assets/css/static-main.css
@@ -50,7 +50,9 @@ pre {
 
 a {
     background-color: transparent;
-    -webkit-text-decoration-skip: objects
+    -webkit-text-decoration-skip: objects;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
 }
 
 abbr[title] {

--- a/assets/css/static-main.css
+++ b/assets/css/static-main.css
@@ -73,7 +73,9 @@ code,
 kbd,
 samp {
     font-family: monospace, monospace;
-    font-size: 1em
+    font-size: 1em;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
 }
 
 dfn {

--- a/production/technical_userguide.md
+++ b/production/technical_userguide.md
@@ -256,7 +256,7 @@ If the request was successful, a `202 Accepted` response code will be returned a
 
 **Headers**
 
-* Content-Location: https://api.bcda.cms.gov/api/v1/jobs/42
+* `Content-Location: https://api.bcda.cms.gov/api/v1/jobs/42`
 
 #### 3. Check the status of the export job
 

--- a/sandbox/technical_user_guide.md
+++ b/sandbox/technical_user_guide.md
@@ -316,7 +316,7 @@ If the request was successful, a `202 Accepted` response code will be returned a
 
 **Headers**
 
-* Content-Location: https://sandbox.bcda.cms.gov/api/v1/jobs/42
+* `Content-Location: https://sandbox.bcda.cms.gov/api/v1/jobs/42`
 
 #### 3. Check the status of the export job
 


### PR DESCRIPTION
### Fixes: 
- [BCDA-2313](https://jira.cms.gov/browse/BCDA-2313)
- [BCDA-2318](https://jira.cms.gov/browse/BCDA-2318)
- [BCDA-2320](https://jira.cms.gov/browse/BCDA-2320)
- [BCDA-2322](https://jira.cms.gov/browse/BCDA-2322)

At extreme zoom levels, even mid-length URL's require the reader to scroll.  This PR applies wrapping (even mid-"word") to ease zoomed reading.

### Proposed Changes
- Apply word wrapping CSS to `<code>` and `<a>` elements
- Ensure all non-linkable URL's are wrapped in `<code>` elements

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

No data has changed; just line wrapping.

### Acceptance Validation
#### Before
![Screen Shot 2020-02-25 at 8 57 54 PM](https://user-images.githubusercontent.com/2533561/75305052-f584d400-5812-11ea-9985-bde819e4584a.png)

#### After
![Screen Shot 2020-02-25 at 8 58 08 PM](https://user-images.githubusercontent.com/2533561/75305058-fa498800-5812-11ea-8dea-053527a4be2f.png)

### Feedback Requested
Do you prefer a different approach?