### PR TITLE
BCDA-2326 Accessibility: Keyboard navigation for code sections

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,6 +27,7 @@
     <!-- Custom JavaScript -->
     <script src="{{ '/assets/js/main.js' | relative_url }}"></script>
     <script src="{{ '/assets/js/accordion.js' | relative_url }}"></script>
+    <script src="{{ '/assets/js/code.js' | relative_url }}"></script>
 
     <!-- Crazy Egg Script
     BCDA will use this one day.  Just not now

--- a/assets/css/static-main.css
+++ b/assets/css/static-main.css
@@ -6016,6 +6016,21 @@ pre {
     white-space: pre-wrap
 }
 
+/* Visual focus on the all code elements. */
+code[tabindex="0"]:focus {
+    outline: 1px dotted #567482;
+}
+
+/* Visual focus on the pre element, which contain code elements. */
+pre:focus-within {
+    outline: 1px dotted #567482;
+}
+
+/* Cancels visual focus on code elements inside pre element so there isn't a double outline. */
+pre:focus-within code[tabindex="0"]:focus {
+    outline: 0 none;
+}
+
 .button--white {
     color: #fff;
     border: 2px #fff solid;

--- a/assets/js/code.js
+++ b/assets/js/code.js
@@ -1,0 +1,4 @@
+var codeElements = document.getElementsByTagName("code");
+for (var i = 0; i < codeElements.length; i++) {
+    codeElements[i].setAttribute("tabindex", "0");
+}

--- a/assets/js/code.js
+++ b/assets/js/code.js
@@ -1,4 +1,4 @@
-var codeElements = document.getElementsByTagName("code");
-for (var i = 0; i < codeElements.length; i++) {
-    codeElements[i].setAttribute("tabindex", "0");
+let codeElements = document.getElementsByTagName("code");
+for (const i of codeElements) {
+    i.setAttribute("tabindex", "0");
 }


### PR DESCRIPTION
### Fixes [BCDA-2326](https://jira.cms.gov/browse/BCDA-2326)
Some readers of our website may be navigating with the keyboard.  We want our code samples to be reachable by this navigation method.

### Proposed Changes
- Add a `tabindex = "0"` property to all `<code>` tags

### Change Details
Option 1: Because we're writing our site in Markdown and converting it to HTML, it would be nice if we could make a simple change to the template for code blocks.  That _might_ be possible by [overloading the parser](https://github.com/vmg/redcarpet/blob/v3.2.2/README.markdown#and-you-can-even-cook-your-own) used by Jekyll

Option 2: Always manually write the HTML for code blocks.  (I know, right, why did I even include this option!?) 

Option 3: Add a few lines of Javascript to set a `tabindex` property on all code blocks

I chose option 3.

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

No changes are made to values outside the page.

### Acceptance Validation
#### Tab navigation highlights code sample
<img width="646" alt="Screen Shot 2020-03-03 at 8 28 21 PM" src="https://user-images.githubusercontent.com/2533561/75835780-cda2ec80-5d8d-11ea-9268-51b19adc4d3c.png">

### Feedback Requested
- Should we go with option 1 instead?
- Does this work in your favorite browser(s)?
- Other suggestions welcome!