### PR TITLE
BCDA-2314 Accessibility: Increase code block contrast ratio

### DIFF
--- a/assets/css/static-main.css
+++ b/assets/css/static-main.css
@@ -6011,7 +6011,7 @@ pre {
     font: 1rem Consolas, "Liberation Mono", Menlo, Courier, monospace;
     font-size: .9rem;
     line-height: 1.45;
-    color: #567482;
+    color: #203341;
     overflow: auto;
     white-space: pre-wrap
 }
@@ -6247,7 +6247,7 @@ article h2::after {
 
 .highlight {
     background-color: #fff;
-    color: #339392;
+    color: #326867;
 }
 
 #main p img.ug-img {


### PR DESCRIPTION
### Fixes [BCDA-2314](https://jira.cms.gov/browse/BCDA-2314)
Our code blocks need to be readable to those requiring high contrast.  The target contrast ratio is 4.5:1, and we are currently at 3.6:1.

### Proposed Changes
- Choose a similar color for highlighted text blocks that provides a 6.3:1 contrast ratio.

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

No security principles were harmed in this color selection.

### Acceptance Validation
#### Before
![Screen Shot 2020-03-03 at 1 42 16 PM](https://user-images.githubusercontent.com/2533561/75808992-fc04d580-5d55-11ea-936c-53dac8d67edf.png)

#### After
![Screen Shot 2020-03-03 at 12 57 38 PM](https://user-images.githubusercontent.com/2533561/75808983-f7d8b800-5d55-11ea-90f4-1f40e9412496.png)

#### New contrast ratio
![Screen Shot 2020-03-03 at 1 47 24 PM](https://user-images.githubusercontent.com/2533561/75808970-f3ac9a80-5d55-11ea-8b8e-043da2b17475.png)

### Feedback Requested
- We have some wiggle room to select a slightly brighter color.  What do you think?