### PR TITLE
BCDA-2854: Accessibility enhancement - only one h1 per page

### DIFF
--- a/index.md
+++ b/index.md
@@ -9,13 +9,14 @@ subnav-link-gradient: "blueberry-lime-link"
 nav_link: home
 id: home
 sections:
+  - Overview
   - Getting Started
   - Frequently Asked Questions
   - FHIR APIs at CMS
 ---
 
 
-# Overview
+## Overview
 The Beneficiary Claims Data API (BCDA) enables Accountable Care Organizations (ACOs) participating in the Shared Savings Program to retrieve Medicare Part A, Part B, and Part D claims data for their prospectively assigned or assignable beneficiaries. In the production environment, the API provides data parallel to Claim and Claim Line Feed (CCLF) files*, currently provided monthly to Shared Savings Program ACOs by CMS. This includes Medicare claims data for instances in which beneficiaries receive care outside of the ACO, allowing a full picture of patient care.
 
 Representatives of Shared Savings Program ACOs are now invited to express their interest in joining the production environment by completing the [BCDA Production Onboarding Request Form](https://airtable.com/shrMbfFSRZkTcSAof){:target="_blank"}. While you wait to onboard in the production environment, we invite developers, analysts, and administrators at Shared Savings Program ACOs to try out the [BCDA Sandbox experience](/sandbox/user-guide/){:target="_self"}.


### PR DESCRIPTION

### Fixes [BCDA-2854](https://jira.cms.gov/browse/BCDA-2854)

According to a `508 Compliance` scan, this homepage has two `h1` tags. The `Overview`  can become `h2`.

### Change Details

- Converted `Overview` section to `h2`.
- Added a link to the `Overview` section on the sidebar.

### Security Implications

No PHI/PII is affected by this change.

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications


### Acceptance Validation

Before:

<img width="1150" alt="Screen Shot 2020-03-21 at 3 22 30 PM" src="https://user-images.githubusercontent.com/37818548/77234987-abc8a880-6b88-11ea-9941-f6ad17d5f48c.png">


After:

<img width="1197" alt="Screen Shot 2020-03-21 at 3 24 33 PM" src="https://user-images.githubusercontent.com/37818548/77235004-c733b380-6b88-11ea-9549-77751834c544.png">



### Feedback Requested

Please review.
