### PR TITLE
BCDA-2852: Accessibility enhancement - remove unnecessary `aria-labelledby`

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -25,7 +25,7 @@ layout: default
   <div class="ds-l-row">
     <div class="ds-l-col--4 ds-u-margin-left--right ds-u-display--none ds-u-sm-display--block" role="complementary">
       <nav aria-label="Page" class="subnav">
-        <ul class="ds-c-list ds-c-list--bare" id="mainNav" aria-labelledby="page-sub-nav">
+        <ul class="ds-c-list ds-c-list--bare" id="mainNav">
           {% for item in page.sections %}
             <li><a href="#{{ item | slugify }}" aria-label="{{ item }} section, current page" class="ds-u-display--block {{ page.subnav-link-gradient }}" aria-label="{{ item }} section, current page">{{ item }}</a></li>
           {% endfor %}


### PR DESCRIPTION

### Fixes [BCDA-2852](https://jira.cms.gov/browse/BCDA-2852)

According to a `508 Compliance` scan, this homepage has an unnecessary `aria-labelledby` attribute.

### Change Details

- Removed unnecessary attribute.

### Security Implications

No PHI/PII is affected by this change.

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications


### Acceptance Validation

Site renders locally with no visible regression.

### Feedback Requested

Please review.
