### PR TITLE
BCDA-2855: Improves HTML markup to fix Axe landmark errors

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -42,4 +42,23 @@
   <nav aria-label="Secondary" class="mobile-nav-items">
     <!-- Items Appended Here by JS -->
   </nav>
+  <div class="ds-base">
+    <div class="blueberry-lime-gradient-background main-header ds-u-margin-bottom--2 ds-u-lg-margin-bottom--5">
+      <div class="api-pattern">
+        <div class="">
+          <div class="ds-l-container">
+            <div class="ds-l-row">
+              <div class="content_buffer ds-l-sm-cold--12 ds-l-xl-col--10 ds-u-margin-left--auto ds-u-padding-x--4"> <!-- ds-u-margin-left--auto ds-u-padding-x--4 -->
+                  <h1 class="ds-display">{{ page.title | escape }}</h1>
+                  <p class="ds-text--lead">
+                    {{ page.description | escape }}
+                  </p>
+                  {% include global_nav.html %}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+    </div>
+  </div>
 </header>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,29 +1,9 @@
 ---
 layout: default
 ---
-<div class="ds-base">
-  <div class="blueberry-lime-gradient-background main-header ds-u-margin-bottom--2 ds-u-lg-margin-bottom--5">
-    <div class="api-pattern">
-      <div class="">
-        <div class="ds-l-container">
-          <div class="ds-l-row">
-            <div class="content_buffer ds-l-sm-cold--12 ds-l-xl-col--10 ds-u-margin-left--auto ds-u-padding-x--4"> <!-- ds-u-margin-left--auto ds-u-padding-x--4 -->
-                <h1 class="ds-display">{{ page.title | escape }}</h1>
-                <p class="ds-text--lead">
-                  {{ page.description | escape }}
-                </p>
-                {% include global_nav.html %}
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-  </div>
-</div>
-
-<section class="ds-l-container ds-base">
+<main id="main" class="ds-l-container ds-base">
   <div class="ds-l-row">
-    <div class="ds-l-col--4 ds-u-margin-left--right ds-u-display--none ds-u-sm-display--block" role="complementary">
+    <div class="ds-l-col--4 ds-u-margin-left--right ds-u-display--none ds-u-sm-display--block">
       <nav aria-label="Page" class="subnav">
         <ul class="ds-c-list ds-c-list--bare" id="mainNav">
           {% for item in page.sections %}
@@ -34,7 +14,7 @@ layout: default
     </div>
 
 
-    <article class="ds-l-col--12 ds-l-sm-col--7 {{ page.badge | slugify }}" id="main" role="main">
+    <article class="ds-l-col--12 ds-l-sm-col--7 {{ page.badge | slugify }}">
       {{ content }}
 
       <div class="bcda_callout">
@@ -50,4 +30,4 @@ layout: default
 
 
   </div>
-</section>
+</main>


### PR DESCRIPTION
<!--

--- PR Hygiene Checklist ---

1. Make sure your branch is named with this format: `user-initials/description-ABC-123`. For example, `jj/add-awesomeness-bcda-99999`
2. Update the PR title: `bcda-99999 Feature: Add Awesomeness`
3. Edit the text below - do not leave placeholders in the text.
4. Add any other details that will be helpful for the reviewers: details description, screenshots, etc
5. Request a review from someone/multiple someones
-->

<!-- Replace xxx with the JIRA ticket number: -->

### Fixes [BCDA-2855](https://jira.cms.gov/browse/BCDA-2855)

<!-- Describe the problem being solved here: -->

### Proposed Changes

- Move page h1 and main navigation into header element. Puts this content inside a landmark to avoid an Axe error.
- Changes the section element to a main one, putting that landmark on the same level as the header and footer elements. Also, adds the `id="main"` so the skip link works. Removes the `role="main"` from the article element; not needed now. And also removes the `id="main"` from the article element.
- Remove the `role="complementary"` from the container div on page navigation. This fixes an Axe error related to nesting landmarks, in this case, having an complementary one inside a main one.

### Security Implications

None.

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

### Acceptance Validation

No new Axe errors are present now:

![Screen Shot 2020-03-24 at 3 13 03 PM](https://user-images.githubusercontent.com/1473618/77467317-2c361600-6de2-11ea-8abb-d1aef47e6110.png)

### Feedback Requested

I tested all the pages to make sure moving some of the elements into the header didn't cause any issues, but it would be good to double check. Especially by someone more familiar with the code base.