### PR TITLE
BCDA-2853: Use `aria-expanded` on the mobile menu button

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -33,7 +33,7 @@
       </div>
     </a>
     <!-- Mobile Nav Trigger Button -->
-    <button class="mobile-nav-trigger-button" href="#">
+    <button class="mobile-nav-trigger-button" type="button" aria-expanded="false">
       <span class="mobile-nav-trigger-text">Menu</span>
       <i class="mobile-nav-icon" data-feather="menu"></i>
     </button>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,6 +28,7 @@
     <script src="{{ '/assets/js/main.js' | relative_url }}"></script>
     <script src="{{ '/assets/js/accordion.js' | relative_url }}"></script>
     <script src="{{ '/assets/js/code.js' | relative_url }}"></script>
+    <script src="{{ 'assets/js/mobile-nav-trigger-button.js' | relative_url }}"></script>
 
     <!-- Crazy Egg Script
     BCDA will use this one day.  Just not now

--- a/assets/js/mobile-nav-trigger-button.js
+++ b/assets/js/mobile-nav-trigger-button.js
@@ -1,0 +1,14 @@
+var acc = document.getElementsByClassName("mobile-nav-trigger-button");
+var i;
+
+for (i = 0; i < acc.length; i++) {
+    acc[i].addEventListener("click", function() {
+        var expanded = this.getAttribute('aria-expanded')
+        if (expanded === 'false') {
+          this.setAttribute('aria-expanded', 'true')
+        } else {
+          this.setAttribute('aria-expanded', 'false')
+        }
+    });
+}
+


### PR DESCRIPTION


### Fixes [BCDA-2853](https://jira.cms.gov/browse/BCDA-2853)

The button that toggles the mobile menu for users can be improved for screen reader users. Adding an additional aria attribute will help them understand that its functionality.

### Change Details

- Added `type="button"` to the mobile menu button
- Added `aria-expanded="false"` to the mobile menu button
- Removed the `href` from the mobile menu button
- Added a script to toggle `aria-expanded` on the mobile menu button

### Security Implications

No PHI/PII is affected by this change.

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications


### Acceptance Validation

Tested locally using a mobile viewport emulator.

Inactive:

<img width="369" alt="Screen Shot 2020-03-28 at 8 47 31 PM" src="https://user-images.githubusercontent.com/37818548/77837289-721e1180-7135-11ea-9f06-b63a094e39eb.png">

Active:

<img width="365" alt="Screen Shot 2020-03-28 at 8 47 46 PM" src="https://user-images.githubusercontent.com/37818548/77837291-7f3b0080-7135-11ea-870e-31bd8fa18b89.png">



### Feedback Requested

Please review.
