### PR TITLE
BCDA-2857: Use `aria-expanded` on the accordion button

### DIFF
--- a/assets/js/accordion.js
+++ b/assets/js/accordion.js
@@ -12,6 +12,13 @@ for (i = 0; i < acc.length; i++) {
         } else {
             contentDiv.style.display = "block";
         }
+
+        var expanded = this.getAttribute('aria-expanded')
+        if (expanded === 'false') {
+          this.setAttribute('aria-expanded', 'true')
+        } else {
+          this.setAttribute('aria-expanded', 'false')
+        }
     });
 }
 

--- a/sandbox/technical_user_guide.md
+++ b/sandbox/technical_user_guide.md
@@ -32,7 +32,7 @@ The Beneficiary Claims Data API is currently accessible as an open sandbox envir
 
 We have provided five sets of synthetic credentials for use in the sandbox, corresponding to various amounts of synthetic beneficiaries. We suggest testing with the credentials that most closely align with the size of your ACO, so that you can get a feel for working with a similar amount of synthetic data to that which you’ll receive in production.
 
-<button class="accordion"> Extra-Small ACO (50 synthetic beneficiaries) </button>
+<button class="accordion" type="button" aria-expanded="false"> Extra-Small ACO (50 synthetic beneficiaries) </button>
 <div class="acc_content">
 Client ID:
 {%- capture client_id -%}
@@ -49,7 +49,7 @@ f9780d323588f1cdfc3e63e95a8cbdcdd47602ff48a537b51dc5d7834bf466416a716bd4508e904a
 {% include copy_snippet.md code=client_secret %}
 </div>
 
-<button class="accordion"> Small ACO (2,500 synthetic beneficiaries) </button>
+<button class="accordion" type="button" aria-expanded="false"> Small ACO (2,500 synthetic beneficiaries) </button>
 <div class="acc_content">
 Client ID:
 {%- capture client_id -%}
@@ -66,7 +66,7 @@ Client Secret:
 {% include copy_snippet.md code=client_secret %}
 </div>
 
-<button class="accordion"> Medium ACO (7,500 synthetic beneficiaries) </button>
+<button class="accordion" type="button" aria-expanded="false"> Medium ACO (7,500 synthetic beneficiaries) </button>
 <div class="acc_content">
 Client ID:
 {%- capture client_id -%}
@@ -83,7 +83,7 @@ e1c920141c4aca6b8f726fa8aa0f7b55e095fd1ea3368a5f24b3636fdc907f113d6677977c7259dd
 {% include copy_snippet.md code=client_secret %}
 </div>
 
-<button class="accordion"> Large ACO (20,000 synthetic beneficiaries) </button>
+<button class="accordion" type="button" aria-expanded="false"> Large ACO (20,000 synthetic beneficiaries) </button>
 <div class="acc_content">
 Client ID:
 {%- capture client_id -%}
@@ -100,7 +100,7 @@ Client Secret:
 {% include copy_snippet.md code=client_secret %}
 </div>
 
-<button class="accordion"> Extra-Large ACO (30,000 synthetic beneficiaries) </button>
+<button class="accordion" type="button" aria-expanded="false"> Extra-Large ACO (30,000 synthetic beneficiaries) </button>
 <div class="acc_content">
 Client ID:
 {%- capture client_id -%}

--- a/sandbox/user_guide.md
+++ b/sandbox/user_guide.md
@@ -48,7 +48,7 @@ In the sandbox environment, we provide generic credentials for you to use. These
 
 We have provided five sets of synthetic credentials for use in the sandbox, corresponding to various amounts of synthetic beneficiaries. We suggest testing with the credentials that most closely align with the size of your ACO, so that you can get a feel for working with a similar amount of synthetic data to that which you’ll receive in production.
 
-<button class="accordion"> Extra-Small ACO (50 synthetic beneficiaries) </button>
+<button class="accordion" type="button" aria-expanded="false"> Extra-Small ACO (50 synthetic beneficiaries) </button>
 <div class="acc_content">
 Client ID:
 {%- capture client_id -%}
@@ -65,7 +65,7 @@ f9780d323588f1cdfc3e63e95a8cbdcdd47602ff48a537b51dc5d7834bf466416a716bd4508e904a
 {% include copy_snippet.md code=client_secret %}
 </div>
 
-<button class="accordion"> Small ACO (2,500 synthetic beneficiaries) </button>
+<button class="accordion" type="button" aria-expanded="false"> Small ACO (2,500 synthetic beneficiaries) </button>
 <div class="acc_content">
 Client ID:
 {%- capture client_id -%}
@@ -82,7 +82,7 @@ Client Secret:
 {% include copy_snippet.md code=client_secret %}
 </div>
 
-<button class="accordion"> Medium ACO (7,500 synthetic beneficiaries) </button>
+<button class="accordion" type="button" aria-expanded="false"> Medium ACO (7,500 synthetic beneficiaries) </button>
 <div class="acc_content">
 Client ID:
 {%- capture client_id -%}
@@ -99,7 +99,7 @@ e1c920141c4aca6b8f726fa8aa0f7b55e095fd1ea3368a5f24b3636fdc907f113d6677977c7259dd
 {% include copy_snippet.md code=client_secret %}
 </div>
 
-<button class="accordion"> Large ACO (20,000 synthetic beneficiaries) </button>
+<button class="accordion" type="button" aria-expanded="false"> Large ACO (20,000 synthetic beneficiaries) </button>
 <div class="acc_content">
 Client ID:
 {%- capture client_id -%}
@@ -116,7 +116,7 @@ Client Secret:
 {% include copy_snippet.md code=client_secret %}
 </div>
 
-<button class="accordion"> Extra-Large ACO (30,000 synthetic beneficiaries) </button>
+<button class="accordion" type="button" aria-expanded="false"> Extra-Large ACO (30,000 synthetic beneficiaries) </button>
 <div class="acc_content">
 Client ID:
 {%- capture client_id -%}


### PR DESCRIPTION

### Fixes [BCDA-2857](https://jira.cms.gov/browse/BCDA-2857)

The button that toggles the accordions for users can be improved for screen reader users. Adding an additional aria attribute will help them understand that its functionality.

### Change Details

- Added `type="button"` to the accordion button
- Added `aria-expanded="false"` to the accordion button
- Added a script to toggle `aria-expanded` on the accordion button

### Security Implications

No PHI/PII is affected by this change.

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications


### Acceptance Validation

Tested locally.

Inactive:

<img width="455" alt="Screen Shot 2020-03-28 at 9 04 10 PM" src="https://user-images.githubusercontent.com/37818548/77837476-bf02e780-7137-11ea-9c40-d55b514c981c.png">


Active:

<img width="571" alt="Screen Shot 2020-03-28 at 9 04 21 PM" src="https://user-images.githubusercontent.com/37818548/77837477-c1654180-7137-11ea-8f6b-3855bd66e12b.png">




### Feedback Requested

Please review.
