### PR TITLE
BCDA 2856: Update colors on focus to meet accessibility requirements

### DIFF
--- a/assets/css/static-main.css
+++ b/assets/css/static-main.css
@@ -6831,7 +6831,6 @@ header {
 
 .ds-c-desktop-nav .desktop-nav-items a:hover,
 .mobile-nav-items a:hover {
-    text-decoration: underline;
     color: #000
 }
 
@@ -7535,7 +7534,6 @@ article h2::after {
 }
 
 .topmenu:active,
-.topmenu:focus,
 .topmenu:hover,
 .topmenu.active {
     background-color: #fff;
@@ -7602,7 +7600,6 @@ article h2::after {
 .accordion_active {
     border: 2px #fff solid;
     background-color: #fff;
-    color: #339392
 }
 
 .acc_content {
@@ -7660,8 +7657,9 @@ pre:focus-within code[tabindex="0"]:focus {
 }
 
 .ds-c-link:focus, .ds-c-link:focus:visited, a:focus, a:focus:visited,
+.ds-c-desktop-nav .desktop-nav-items a:focus, .mobile-nav-items a:focus,
 a.ds-c-button.ds-u-margin-top--4:focus, button.accordion:focus, button.accordion:hover,
 .button p a:focus {
     background-color: #68C1BF;
-    color: white;
+    color: #212121;
 }


### PR DESCRIPTION
<!--

--- PR Hygiene Checklist ---

1. Make sure your branch is named with this format: `user-initials/description-ABC-123`. For example, `jj/add-awesomeness-bcda-99999`
2. Update the PR title: `bcda-99999 Feature: Add Awesomeness`
3. Edit the text below - do not leave placeholders in the text.
4. Add any other details that will be helpful for the reviewers: details description, screenshots, etc
5. Request a review from someone/multiple someones
-->

<!-- Replace xxx with the JIRA ticket number: -->

### Fixes [BCDA-2856](https://jira.cms.gov/browse/BCDA-2856)

Updates focus colors in a few spots to meet contrast requirements.

### Proposed Changes

- Remove text decoration underline on hover on "Join" link to make it consistent with site title link.
- Remove `.topmenu:focus` CSS to make those links receive proper color on focus.
- Remove `color: #339392` on `.accordion_active` so it meets contrast requirements when accordions are expanded.
- Add `.ds-c-desktop-nav .desktop-nav-items a:focus, .mobile-nav-items a:focus` to focus rules so they go the proper color.
- Change main focus color from white to `#212121` so it meets contrast requirements.

### Change Details

<!-- Add detailed discussion of changes here: -->

### Security Implications

None.

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

### Acceptance Validation

Colors now pass contrast. See screenshots:

![Screen Shot 2020-03-31 at 4 55 59 PM](https://user-images.githubusercontent.com/1473618/78074651-1a6bea00-7371-11ea-8200-4188499343e8.png)

![Screen Shot 2020-03-31 at 4 56 20 PM](https://user-images.githubusercontent.com/1473618/78074659-1fc93480-7371-11ea-8b96-307e66b70413.png)

![Screen Shot 2020-03-31 at 4 57 27 PM](https://user-images.githubusercontent.com/1473618/78074734-38d1e580-7371-11ea-9fcb-c845a62699fd.png)

![Screen Shot 2020-03-31 at 4 58 01 PM](https://user-images.githubusercontent.com/1473618/78074750-3e2f3000-7371-11ea-83ef-c309d705167b.png)

![Screen Shot 2020-03-31 at 4 58 39 PM](https://user-images.githubusercontent.com/1473618/78074761-425b4d80-7371-11ea-85da-71be5d87c344.png)

### Feedback Requested

Feel free to test it out by tabbing through the pages, double checking to see if the style changes interfered with anything else.