### PR TITLE
Adding Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 dist: bionic
 
+# Don't email me the results of the test runs.
+notifications:
+  email: false
+  
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ dist: bionic
 services:
   - docker
 
-script: ./scripts/run-build.sh
+script: ./scripts/build_and_test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+dist: bionic
+
+services:
+  - docker
+
+script: ./scripts/run-build.sh

--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -1,10 +1,26 @@
 #!/usr/bin/env bash
 
-# build
-docker-compose -f docker-compose.yml build static_site
+set -eo pipefail
 
-# test
-docker-compose run -u $(id -u ${USER}):$(id -g ${USER}) --publish 4000:4000 --rm --entrypoint "bundle exec jekyll serve -H 0.0.0.0" -d static_site
-sleep 20
-curl localhost:4000 | grep "Join the Google Group"
-docker-compose down
+docker_cleanup()
+{
+    docker-compose down
+}
+
+build() {
+    docker-compose -f docker-compose.yml build static_site
+}
+
+test() {
+    trap docker_cleanup EXIT
+    docker-compose run -u "$(id -u "${USER}")":"$(id -g "${USER}")" --publish 4000:4000 --rm --entrypoint "bundle exec jekyll serve -H 0.0.0.0" -d static_site
+    sleep 20
+    curl localhost:4000 | grep "Join the Google Group"
+}
+
+main() {
+    build
+    test
+}
+
+main

--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -15,7 +15,7 @@ test() {
     trap docker_cleanup EXIT
     docker-compose run -u "$(id -u "${USER}")":"$(id -g "${USER}")" --publish 4000:4000 --rm --entrypoint "bundle exec jekyll serve -H 0.0.0.0" -d static_site
     sleep 20
-    curl localhost:4000 | grep "Join the Google Group"
+    curl localhost:4000 | grep "blah blah blah"
 }
 
 main() {

--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -15,7 +15,7 @@ test() {
     trap docker_cleanup EXIT
     docker-compose run -u "$(id -u "${USER}")":"$(id -g "${USER}")" --publish 4000:4000 --rm --entrypoint "bundle exec jekyll serve -H 0.0.0.0" -d static_site
     sleep 20
-    curl localhost:4000 | grep "blah blah blah"
+    curl localhost:4000 | grep "Join the Google Group"
 }
 
 main() {

--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
+
+# build
 docker-compose -f docker-compose.yml build static_site
+
+# test
 docker-compose run -u $(id -u ${USER}):$(id -g ${USER}) --publish 4000:4000 --rm --entrypoint "bundle exec jekyll serve -H 0.0.0.0" -d static_site
 sleep 20
-curl localhost:4000 | grep "Join the Google Group" 
+curl localhost:4000 | grep "Join the Google Group"
+docker-compose down

--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+docker-compose -f docker-compose.yml build static_site
+docker-compose run -u $(id -u ${USER}):$(id -g ${USER}) --publish 4000:4000 --rm --entrypoint "bundle exec jekyll serve -H 0.0.0.0" -d static_site
+sleep 20
+curl localhost:4000 | grep "Join the Google Group" 


### PR DESCRIPTION
### Fixes [BCDA-2934](https://jira.cms.gov/browse/BCDA-2934)

This branch adds continuous integration with travis to the static site.

### Proposed Changes

* Adding `.travis.yml` travis configuration
* Adding `scripts/build_and_test.sh` script

### Change Details

The Travis CI configuration specifies that we're using ubuntu 18.04 (bionic) and the docker service.

To test the site, it runs jekyll serve and greps the response from a request for the home page.

Note that the test steps in `build_and_test.sh` are not dependent on the build step. We can use the build step as a stub for deploying the static site assets.

### Security Implications

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

### Acceptance Validation

To test this Travis config, I forked the repo to my personal GitHub and enabled Travis CI. Travis will need to be enabled for `https://github.com/CMSgov/bcda-static-site/` on [this page](https://travis-ci.org/organizations/CMSgov/repositories) before this ticket can be considered done.

### Feedback Requested

Does anyone have permission to enable CI for `bcda-static-site`?

All feedback is welcome. 
