### PR TITLE
Pin `jekyll/builder` image to version 3.8

### DIFF
--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -1,4 +1,4 @@
-FROM jekyll/builder
+FROM jekyll/builder:3.8
 
 WORKDIR /bcda-site-static
 COPY . .


### PR DESCRIPTION
### Fixes Bug In Build Process

The `jekyll/builder` image was [updated yesterday on Dockerhub](https://hub.docker.com/r/jekyll/builder/tags).  This new image is not compatible with our processes, causing the following error:

```
Bundler::PermissionError: There was an error while trying to write to
`/usr/gem/cache`. It is likely that you need to grant write permissions for that
path.
An error occurred while installing public_suffix (3.0.3), and Bundler cannot
continue.
Make sure that `gem install public_suffix -v '3.0.3' --source
'https://rubygems.org/'` succeeds before bundling.

In Gemfile:
  minima was resolved to 2.5.0, which depends on
    jekyll-feed was resolved to 0.11.0, which depends on
      jekyll was resolved to 3.8.5, which depends on
        addressable was resolved to 2.6.0, which depends on
          public_suffix
ERROR: Service 'static_site' failed to build: The command 'bundle install' returned a non-zero code: 5
```

### Change Details

To ensure our pipeline can proceed with no issues, the `Dockerfile` that we use to build the static site has been pinned to the version of `jekyll/builder` that we were using before yesterday's community update.  

In addition, [a ticket was created](https://jira.cms.gov/browse/BCDA-3014) (to be prioritized and implemented in the future) to update Ruby by-way-of updating to the latest `jekyll/builder` image.

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change


### Acceptance Validation

Static site is building successfully locally and on Travis.

### Feedback Requested

Please review.
