### PR TITLE
BCDA-2933: Add alternate cURL command to Basic auth technical guides

### DIFF
--- a/production/technical_userguide.md
+++ b/production/technical_userguide.md
@@ -42,7 +42,7 @@ Once you have your credentials, you will:
 
 **Currently, access tokens expire after twenty minutes.**
 
-### Authentication Walkthrough
+### Basic Authentication Walkthrough
 
 You can follow the steps for [authenticating and receiving a token using Swagger](/production/user-guide/#setting-up-your-credentials-in-swagger){:target="_self"}, or follow the walk-through below if you are using the command line or terminal.
 
@@ -56,8 +56,6 @@ Client Secret:
 64916fe96f71adc79c5735e49f4e72f18ff941d0dd62cf43ee1ae0857e204f173ba10e4250c12c48
 ```
 
-### Encoded Basic authentication:
-
 **Request**
 
 `POST /auth/token`
@@ -67,15 +65,42 @@ Client Secret:
 * `Accept: application/json`
 * `Authorization: <Encoded Basic authentication>`
 
-In the following cURL command, notice that we have concatenated the base64 encoding of the 'Client ID":" Client Secret' as the argument to the -H flag.
+**cURL commands**
+
+You can choose one of two cURL commands to use.
+
+**Option 1, which performs Basic authentication by passing in an additional header**
+
+Format:
 
 ```
-curl -d '' -X POST "https://api.bcda.cms.gov/auth/token" -H "accept: application/json" -H "authorization: Basic MDk4NjlhN2YtNDZjZS00OTA4LWE5MTQtNjEyOWQwODBhMmFlOjY0OTE2ZmU5NmY3MWFkYzc5YzU3MzVlNDlmNGU3MmYxOGZmOTQxZDBkZDYyY2Y0M2VlMWFlMDg1N2UyMDRmMTczYmExMGU0MjUwYzEyYzQ4"
+curl -H "authorization: Basic [base64-encoded clientId:secret]"
+```
+
+Example:
+
+```
+curl -d '' -X POST "https://sandbox.bcda.cms.gov/auth/token" -H "accept: application/json" -H "authorization: Basic Mzg0MWM1OTQtYThjMC00MWU1LTk4Y2MtMzhiYjQ1MzYwZDNjOm\
+Y5NzgwZDMyMzU4OGYxY2RmYzNlNjNlOTVhOGNiZGNkZDQ3NjAy\
+ZmY0OGE1MzdiNTFkYzVkNzgzNGJmNDY2NDE2YTcxNmJkNDUwOGU5MDRh"
+```
+
+**Option 2, which does only requires you to submit your clientId and secret**
+
+
+Format:
+
+```
+curl --user clientId:secret
+```
+
+Example:
+
+```
+curl --user 3841c594-a8c0-41e5-98cc-38bb45360d3c:f9780d323588f1cdfc3e63e95a8cbdcdd47602ff48a537b51dc5d7834bf466416a716bd4508e904a
 ```
 
 **Response**
-
-You will receive a `200 OK` response and an access token if your credentials were accepted, with a body like so:
 
 ```
 {

--- a/production/technical_userguide.md
+++ b/production/technical_userguide.md
@@ -90,7 +90,7 @@ With this option, the user can take advantage of cURL's built-in ability to base
 Example:
 
 ```
-curl -X POST "https://sandbox.bcda.cms.gov/auth/token" --user 3841c594-a8c0-41e5-98cc-38bb45360d3c:f9780d323588f1cdfc3e63e95a8cbdcdd47602ff48a537b51dc5d7834bf466416a716bd4508e904a -H "authorization: Basic Mzg0MWM1OTQtYThjMC00MWU1LTk4Y2MtMzhiYjQ1MzYwZDNjOm\
+curl -d '' -X POST "https://sandbox.bcda.cms.gov/auth/token" --user 3841c594-a8c0-41e5-98cc-38bb45360d3c:f9780d323588f1cdfc3e63e95a8cbdcdd47602ff48a537b51dc5d7834bf466416a716bd4508e904a -H "authorization: Basic Mzg0MWM1OTQtYThjMC00MWU1LTk4Y2MtMzhiYjQ1MzYwZDNjOm\
 Y5NzgwZDMyMzU4OGYxY2RmYzNlNjNlOTVhOGNiZGNkZDQ3NjAy\
 ZmY0OGE1MzdiNTFkYzVkNzgzNGJmNDY2NDE2YTcxNmJkNDUwOGU5MDRh" 
 ```

--- a/production/technical_userguide.md
+++ b/production/technical_userguide.md
@@ -42,7 +42,7 @@ Once you have your credentials, you will:
 
 **Currently, access tokens expire after twenty minutes.**
 
-### Basic Authentication Walkthrough
+### Authentication Walkthrough
 
 You can follow the steps for [authenticating and receiving a token using Swagger](/production/user-guide/#setting-up-your-credentials-in-swagger){:target="_self"}, or follow the walk-through below if you are using the command line or terminal.
 
@@ -69,13 +69,15 @@ Client Secret:
 
 You can choose one of two cURL commands to use.
 
-**Option 1, which performs Basic authentication by passing in an additional header**
+**Option 1, which requires base-64 encoding be performed on your clientId and secret**
 
 Format:
 
 ```
 curl -H "authorization: Basic [base64-encoded clientId:secret]"
 ```
+
+In the following cURL command, we have concatenated the base64 encoding of the 'Client ID":" Client Secret' as the argument to the -H flag.
 
 Example:
 
@@ -85,7 +87,7 @@ Y5NzgwZDMyMzU4OGYxY2RmYzNlNjNlOTVhOGNiZGNkZDQ3NjAy\
 ZmY0OGE1MzdiNTFkYzVkNzgzNGJmNDY2NDE2YTcxNmJkNDUwOGU5MDRh"
 ```
 
-**Option 2, which does only requires you to submit your clientId and secret**
+**Option 2, which takes advantage of cURL's ability to base-64 encode your clientId and secret**
 
 
 Format:

--- a/production/technical_userguide.md
+++ b/production/technical_userguide.md
@@ -71,13 +71,9 @@ You can choose one of two cURL commands to use.
 
 **Option 1, which requires base-64 encoding be performed on your clientId and secret**
 
-Format:
+With this option, you must base-64 encode the `clientId` and `secret`.  Once that is performed, the encoded credentials can be passed to `curl` as a header with the form: `authorization: Basic [base64-encoded clientId:secret]`
 
-```
-curl -H "authorization: Basic [base64-encoded clientId:secret]"
-```
-
-In the following cURL command, we have concatenated the base64 encoding of the 'Client ID":" Client Secret' as the argument to the -H flag.
+In the following cURL command, we have concatenated the base64 encoding of the 'Client ID : Secret' as the argument to the -H flag.
 
 Example:
 
@@ -89,17 +85,14 @@ ZmY0OGE1MzdiNTFkYzVkNzgzNGJmNDY2NDE2YTcxNmJkNDUwOGU5MDRh"
 
 **Option 2, which takes advantage of cURL's ability to base-64 encode your clientId and secret**
 
-
-Format:
-
-```
-curl --user clientId:secret
-```
+With this option, the user can take advantage of cURL's built-in ability to base-64 encode the `clientId` and `secret`, and request and receive their token in a single step.
 
 Example:
 
 ```
-curl --user 3841c594-a8c0-41e5-98cc-38bb45360d3c:f9780d323588f1cdfc3e63e95a8cbdcdd47602ff48a537b51dc5d7834bf466416a716bd4508e904a
+curl -X POST "https://sandbox.bcda.cms.gov/auth/token" --user 3841c594-a8c0-41e5-98cc-38bb45360d3c:f9780d323588f1cdfc3e63e95a8cbdcdd47602ff48a537b51dc5d7834bf466416a716bd4508e904a -H "authorization: Basic Mzg0MWM1OTQtYThjMC00MWU1LTk4Y2MtMzhiYjQ1MzYwZDNjOm\
+Y5NzgwZDMyMzU4OGYxY2RmYzNlNjNlOTVhOGNiZGNkZDQ3NjAy\
+ZmY0OGE1MzdiNTFkYzVkNzgzNGJmNDY2NDE2YTcxNmJkNDUwOGU5MDRh" 
 ```
 
 **Response**

--- a/sandbox/technical_user_guide.md
+++ b/sandbox/technical_user_guide.md
@@ -119,7 +119,7 @@ Client Secret:
 
 To get a token that can be used with protected endpoints, POST the credentials you’ve selected using [Basic Authentication](https://en.wikipedia.org/wiki/Basic_access_authentication){:target="_blank"} to `https://sandbox.bcda.cms.gov/auth/token`.
 
-### Basic Authentication Walkthrough
+### Authentication Walkthrough
 
 
 **Request**
@@ -135,13 +135,15 @@ To get a token that can be used with protected endpoints, POST the credentials y
 
 You can choose one of two cURL commands to use.
 
-**Option 1, which performs Basic authentication by passing in an additional header**
+**Option 1, which requires base-64 encoding be performed on your clientId and secret**
 
 Format:
 
 ```
 curl -H "authorization: Basic [base64-encoded clientId:secret]"
 ```
+
+In the following cURL command, we have concatenated the base64 encoding of the 'Client ID":" Client Secret' as the argument to the -H flag.
 
 Example:
 
@@ -151,8 +153,7 @@ Y5NzgwZDMyMzU4OGYxY2RmYzNlNjNlOTVhOGNiZGNkZDQ3NjAy\
 ZmY0OGE1MzdiNTFkYzVkNzgzNGJmNDY2NDE2YTcxNmJkNDUwOGU5MDRh"
 ```
 
-**Option 2, which does only requires you to submit your clientId and secret**
-
+**Option 2, which takes advantage of cURL's ability to base-64 encode your clientId and secret**
 
 Format:
 
@@ -180,7 +181,7 @@ You will receive a `200 OK` response and an access token if your credentials wer
 
 _Token string abbreviated for readability._
 
-You will receive a 401 Unauthorized response if your credentials are invalid or if your token has expired. No additional information is returned with a 401 response. When you receive a 401 response for a token you were just using successfully, you should request a new access token as outlined above.
+You will receive a `401 Unauthorized` response if your credentials are invalid or if your token has expired. No additional information is returned with a `401` response. When you receive a 401 response for a token you were just using successfully, you should request a new access token as outlined above.
 
 ## Environment
 

--- a/sandbox/technical_user_guide.md
+++ b/sandbox/technical_user_guide.md
@@ -137,13 +137,9 @@ You can choose one of two cURL commands to use.
 
 **Option 1, which requires base-64 encoding be performed on your clientId and secret**
 
-Format:
+With this option, you must base-64 encode the `clientId` and `secret`.  Once that is performed, the encoded credentials can be passed to `curl` as a header with the form: `authorization: Basic [base64-encoded clientId:secret]`
 
-```
-curl -H "authorization: Basic [base64-encoded clientId:secret]"
-```
-
-In the following cURL command, we have concatenated the base64 encoding of the 'Client ID":" Client Secret' as the argument to the -H flag.
+In the following cURL command, we have concatenated the base64 encoding of the 'Client ID : Secret' as the argument to the -H flag.
 
 Example:
 
@@ -155,18 +151,15 @@ ZmY0OGE1MzdiNTFkYzVkNzgzNGJmNDY2NDE2YTcxNmJkNDUwOGU5MDRh"
 
 **Option 2, which takes advantage of cURL's ability to base-64 encode your clientId and secret**
 
-Format:
-
-```
-curl --user clientId:secret
-```
+With this option, the user can take advantage of cURL's built-in ability to base-64 encode the `clientId` and `secret`, and request and receive their token in a single step.
 
 Example:
 
 ```
-curl --user 3841c594-a8c0-41e5-98cc-38bb45360d3c:f9780d323588f1cdfc3e63e95a8cbdcdd47602ff48a537b51dc5d7834bf466416a716bd4508e904a
+curl -X POST "https://sandbox.bcda.cms.gov/auth/token" --user 3841c594-a8c0-41e5-98cc-38bb45360d3c:f9780d323588f1cdfc3e63e95a8cbdcdd47602ff48a537b51dc5d7834bf466416a716bd4508e904a -H "authorization: Basic Mzg0MWM1OTQtYThjMC00MWU1LTk4Y2MtMzhiYjQ1MzYwZDNjOm\
+Y5NzgwZDMyMzU4OGYxY2RmYzNlNjNlOTVhOGNiZGNkZDQ3NjAy\
+ZmY0OGE1MzdiNTFkYzVkNzgzNGJmNDY2NDE2YTcxNmJkNDUwOGU5MDRh" 
 ```
-
 
 **Response**
 
@@ -181,7 +174,7 @@ You will receive a `200 OK` response and an access token if your credentials wer
 
 _Token string abbreviated for readability._
 
-You will receive a `401 Unauthorized` response if your credentials are invalid or if your token has expired. No additional information is returned with a `401` response. When you receive a 401 response for a token you were just using successfully, you should request a new access token as outlined above.
+You will receive a `401 Unauthorized` response if your credentials are invalid or if your token has expired. No additional information is returned with a `401` response. When you receive a `401` response for a token you were just using successfully, you should request a new access token as outlined above.
 
 ## Environment
 

--- a/sandbox/technical_user_guide.md
+++ b/sandbox/technical_user_guide.md
@@ -156,7 +156,7 @@ With this option, the user can take advantage of cURL's built-in ability to base
 Example:
 
 ```
-curl -X POST "https://sandbox.bcda.cms.gov/auth/token" --user 3841c594-a8c0-41e5-98cc-38bb45360d3c:f9780d323588f1cdfc3e63e95a8cbdcdd47602ff48a537b51dc5d7834bf466416a716bd4508e904a -H "authorization: Basic Mzg0MWM1OTQtYThjMC00MWU1LTk4Y2MtMzhiYjQ1MzYwZDNjOm\
+curl -d '' -X POST "https://sandbox.bcda.cms.gov/auth/token" --user 3841c594-a8c0-41e5-98cc-38bb45360d3c:f9780d323588f1cdfc3e63e95a8cbdcdd47602ff48a537b51dc5d7834bf466416a716bd4508e904a -H "authorization: Basic Mzg0MWM1OTQtYThjMC00MWU1LTk4Y2MtMzhiYjQ1MzYwZDNjOm\
 Y5NzgwZDMyMzU4OGYxY2RmYzNlNjNlOTVhOGNiZGNkZDQ3NjAy\
 ZmY0OGE1MzdiNTFkYzVkNzgzNGJmNDY2NDE2YTcxNmJkNDUwOGU5MDRh" 
 ```

--- a/sandbox/technical_user_guide.md
+++ b/sandbox/technical_user_guide.md
@@ -117,15 +117,10 @@ Client Secret:
 {% include copy_snippet.md code=client_secret %}
 </div>
 
-To get a token that can be used with protected endpoints, POST the credentials you've selected using [Basic Authentication](https://en.wikipedia.org/wiki/Basic_access_authentication){:target="_blank"} to `https://sandbox.bcda.cms.gov/auth/token`:
+To get a token that can be used with protected endpoints, POST the credentials you’ve selected using [Basic Authentication](https://en.wikipedia.org/wiki/Basic_access_authentication){:target="_blank"} to `https://sandbox.bcda.cms.gov/auth/token`.
 
+### Basic Authentication Walkthrough
 
-Encoded Basic authentication:
-{%- capture auth_header -%}
-Basic Mzg0MWM1OTQtYThjMC00MWU1LTk4Y2MtMzhiYjQ1MzYwZDNjOmY5NzgwZDMyMzU4OGYxY2RmYzNlNjNlOTVhOGNiZGNkZDQ3NjAyZmY0OGE1MzdiNTFkYzVkNzgzNGJmNDY2NDE2YTcxNmJkNDUwOGU5MDRh
-{%- endcapture -%}
-
-{% include copy_snippet.md code=auth_header %}
 
 **Request**
 
@@ -136,16 +131,56 @@ Basic Mzg0MWM1OTQtYThjMC00MWU1LTk4Y2MtMzhiYjQ1MzYwZDNjOmY5NzgwZDMyMzU4OGYxY2RmYz
 * `Accept: application/json`
 * `Authorization: <Encoded Basic authentication>`
 
-**cURL command**
+**cURL commands**
+
+You can choose one of two cURL commands to use.
+
+**Option 1, which performs Basic authentication by passing in an additional header**
+
+Format:
+
+```
+curl -H "authorization: Basic [base64-encoded clientId:secret]"
+```
+
+Example:
 
 ```
 curl -d '' -X POST "https://sandbox.bcda.cms.gov/auth/token" -H "accept: application/json" -H "authorization: Basic Mzg0MWM1OTQtYThjMC00MWU1LTk4Y2MtMzhiYjQ1MzYwZDNjOm\
 Y5NzgwZDMyMzU4OGYxY2RmYzNlNjNlOTVhOGNiZGNkZDQ3NjAy\
 ZmY0OGE1MzdiNTFkYzVkNzgzNGJmNDY2NDE2YTcxNmJkNDUwOGU5MDRh"
 ```
+
+**Option 2, which does only requires you to submit your clientId and secret**
+
+
+Format:
+
+```
+curl --user clientId:secret
+```
+
+Example:
+
+```
+curl --user 3841c594-a8c0-41e5-98cc-38bb45360d3c:f9780d323588f1cdfc3e63e95a8cbdcdd47602ff48a537b51dc5d7834bf466416a716bd4508e904a
+```
+
+
 **Response**
 
 You will receive a `200 OK` response and an access token if your credentials were accepted.
+
+```
+{
+  “access_token”: “eyJhbGciOiJSUzUxMiIsInR5c ....”,
+  ”token_type”:“bearer”
+}
+```
+
+_Token string abbreviated for readability._
+
+You will receive a 401 Unauthorized response if your credentials are invalid or if your token has expired. No additional information is returned with a 401 response. When you receive a 401 response for a token you were just using successfully, you should request a new access token as outlined above.
 
 ## Environment
 


### PR DESCRIPTION
### Fixes [BCDA-2933](https://jira.cms.gov/browse/BCDA-2933)

Adds alternate cURL command to our Basic auth technical guides (both sandbox and production guides).  The additional cURL command performs base64 encoding with just the clientId and secret; the sole previous cURL command performs base64 encoding by way of concatenating a header. 

### Proposed Changes

* Introduced heading and content parity between the technical sandbox and production guides
* Added the alternate cURL command
* Removed an imprecise `copy-to-clipboard` snippet in the technical sandbox guide

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation

Tested locally.  Flow across technical sandbox and production guides is as follows:

* Authentication and Authorization
   * Basic Authentication Walkthrough
   * Request
   * Headers
   * cURL commands
      * Option 1
      * Option 2
   * Response

### Feedback Requested

* Confirm parity between the technical sandbox and technical production guides
* Evaluate content flow and delivery from a technical readability perspective

