### PR TITLE
Update docs to indicate that _since parameter must be in FHIR instant format

### DIFF
--- a/production/technical_userguide.md
+++ b/production/technical_userguide.md
@@ -700,13 +700,13 @@ Before using `_since` for the first time, we recommend that you retrieve all his
 **Note: Due to limitations in the Beneficiary FHIR Data (BFD) Server, data from before 02-12-2020 is marked with the arbitrary [lastUpdated](https://www.hl7.org/fhir/search.html#lastUpdated){:target="_blank"} date of 01-01-2020. If you input dates between 01-01-2020 and 02-11-2020 in the `_since` parameter, you will receive all historical data for your beneficiaries. Data loads from 02-12-2020 onwards have been marked with accurate dates.**
 
 #### Date and Timezone Formatting
-Dates and times submitted in `_since` must be listed in the FHIR _dateTime_ format (`YYYY-MM-DDThh:mm:ss+zz:zz`). Notice that, if you need to include a time, a timezone must also be specified (`+zz:zz`).
+Dates and times submitted in `_since` must be listed in the FHIR _instant_ format (`YYYY-MM-DDThh:mm:sss+zz:zz`).
 
 * _Sample Date:_ February 20, 2020 12:00 PM EST
-* _dateTime Format:_ YYYY-MM-DDThh:mm:ss+zz:zz
-* _Formatted Sample:_ 2020-02-20T12:00:00.00-05:00
+* _instant Format:_ YYYY-MM-DDThh:mm:sss+zz:zz
+* _Formatted Sample:_ 2020-02-20T12:00:00.000-05:00
 
-More information about the FHIR _dateTime_ format can be found in the [FHIR Datatypes page](https://www.hl7.org/fhir/datatypes.html#dateTime){:target="_blank"}.
+More information about the FHIR _instant_ format can be found in the [FHIR Datatypes page](https://www.hl7.org/fhir/datatypes.html#instant){:target="_blank"}.
 
 #### Usage Examples
 See the [Authentication and Authorization section](/production/technical-user-guide/#authentication-and-authorization){:target="_blank"} above to obtain the API token needed before requesting data from any of the BCDA bulk data endpoints. 

--- a/production/user_guide.md
+++ b/production/user_guide.md
@@ -232,7 +232,7 @@ After retrieving your historical data, it may be helpful to use the date of your
 
 <img class="ug-img" src="/assets/img/since_1.svg" alt="" />
 
-First, click “Try it Out” in the Swagger section for `_since`. Then, enter your desired date into the dialog box labeled "`_since` (Optional)". Dates and times submitted in `_since` must adhere to a specific format for the server to understand. That format is the FHIR _dateTime_ format (`YYYY-MM-DDThh:mm:ss+zz:zz`). Notice that, if you need to include a time, a timezone must also be specified (`+zz:zz`).
+First, click “Try it Out” in the Swagger section for `_since`. Then, enter your desired date into the dialog box labeled "`_since` (Optional)". Dates and times submitted in `_since` must adhere to a specific format for the server to understand. That format is the FHIR _instant_ format (`YYYY-MM-DDThh:mm:ss.sss+zz:zz`).
 
 <img class="ug-img" src="/assets/img/since_2.svg" alt="" />
 
@@ -241,10 +241,10 @@ The example below demonstrates how to convert a date/time combination into the F
 **Date and Time Example**
 
 * _Sample Date:_ February 20, 2020 12:00 PM EST
-* _dateTime Format:_ YYYY-MM-DDThh:mm:ss+zz:zz
-* _Formatted Sample:_ 2020-02-20T12:00:00.00-05:00
+* _instant Format:_ YYYY-MM-DDThh:mm:ss.sss+zz:zz
+* _Formatted Sample:_ 2020-02-20T12:00:00.000-05:00
 
-More information about the FHIR dateTime format can be found on the [FHIR Datatypes page](https://www.hl7.org/fhir/datatypes.html#dateTime){:target="_blank"}.
+More information about the FHIR instant format can be found on the [FHIR Datatypes page](https://www.hl7.org/fhir/datatypes.html#instant){:target="_blank"}.
 
 #### c. Start the job to acquire data from that endpoint
 

--- a/sandbox/technical_user_guide.md
+++ b/sandbox/technical_user_guide.md
@@ -768,7 +768,7 @@ Dates and times submitted in `_since` must be listed in the FHIR _instant_ forma
 
 * _Sample Date:_ February 20, 2020 12:00 PM EST
 * _instant Format:_ YYYY-MM-DDThh:mm:sss+zz:zz
-* _Formatted Sample:_ 2020-02-20T12:00:00.00-05:00
+* _Formatted Sample:_ 2020-02-20T12:00:00.000-05:00
 
 More information about the FHIR _instant_ format can be found in the [FHIR Datatypes page](https://www.hl7.org/fhir/datatypes.html#instant){:target="_blank"}.
 

--- a/sandbox/technical_user_guide.md
+++ b/sandbox/technical_user_guide.md
@@ -764,13 +764,13 @@ For more information on `_since`, please consult the [FHIR standard on query par
 There are a couple of helpful points to keep in mind when using `_since`.
 
 #### Date and Timezone Formatting
-Dates and times submitted in `_since` must be listed in the FHIR _dateTime_ format (`YYYY-MM-DDThh:mm:ss+zz:zz`). Notice that, if you need to include a time, a timezone must also be specified (`+zz:zz`).
+Dates and times submitted in `_since` must be listed in the FHIR _instant_ format (`YYYY-MM-DDThh:mm:sss+zz:zz`).
 
 * _Sample Date:_ February 20, 2020 12:00 PM EST
-* _dateTime Format:_ YYYY-MM-DDThh:mm:ss+zz:zz
+* _instant Format:_ YYYY-MM-DDThh:mm:sss+zz:zz
 * _Formatted Sample:_ 2020-02-20T12:00:00.00-05:00
 
-More information about the FHIR _dateTime_ format can be found in the [FHIR Datatypes page](https://www.hl7.org/fhir/datatypes.html#dateTime){:target="_blank"}.
+More information about the FHIR _instant_ format can be found in the [FHIR Datatypes page](https://www.hl7.org/fhir/datatypes.html#instant){:target="_blank"}.
 
 #### Usage Examples
 See the [Authentication and Authorization section](/sandbox/technical-user-guide/#authentication-and-authorization){:target="_blank"} above to obtain the API token needed before requesting data from any of the BCDA bulk data endpoints. 

--- a/sandbox/user_guide.md
+++ b/sandbox/user_guide.md
@@ -304,7 +304,7 @@ Using the `_since` parameter comprises three steps:
 
 <img class="ug-img" src="/assets/img/since_1.svg" alt="" />
 
-First, click “Try it Out” in the Swagger section for `_since`. Then, enter your desired date into the dialog box labeled "`_since` (Optional)". Dates and times submitted in `_since` must adhere to a specific format for the server to understand. That format is the FHIR _dateTime_ format (`YYYY-MM-DDThh:mm:ss+zz:zz`). Notice that, if you need to include a time, a timezone must also be specified (`+zz:zz`).
+First, click “Try it Out” in the Swagger section for `_since`. Then, enter your desired date into the dialog box labeled "`_since` (Optional)". Dates and times submitted in `_since` must adhere to a specific format for the server to understand. That format is the FHIR _instant_ format (`YYYY-MM-DDThh:mm:ss.sss+zz:zz`).
 
 <img class="ug-img" src="/assets/img/since_2.svg" alt="" />
 
@@ -314,10 +314,10 @@ The example below demonstrates how to convert a date/time combination into the F
 **Date and Time Example**
 
 * _Sample Date:_ February 20, 2020 12:00 PM EST
-* _dateTime Format:_ YYYY-MM-DDThh:mm:ss+zz:zz
-* _Formatted Sample:_ 2020-02-20T12:00:00.00-05:00
+* _instant Format:_ YYYY-MM-DDThh:mm:sss+zz:zz
+* _Formatted Sample:_ 2020-02-20T12:00:00.000-05:00
 
-More information about the FHIR dateTime format can be found on the [FHIR Datatypes page](https://www.hl7.org/fhir/datatypes.html#dateTime){:target="_blank"}.
+More information about the FHIR instant format can be found on the [FHIR Datatypes page](https://www.hl7.org/fhir/datatypes.html#instant){:target="_blank"}.
 
 #### b. Start the job to acquire data from that endpoint
 


### PR DESCRIPTION

### Related To [BCDA-3048](https://jira.cms.gov/browse/BCDA-3048)

`since` parameter validation has been refined/restricted to only allow FHIR `instant` datatype, as per the Bulk FHIR Specification.  Our documentation should reflect this as well.

### Change Details

`since` parameter documentation has been updated to indicate FHIR `instant` datatype, as per the Bulk FHIR Specification.

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation

Local rendering is accurate.

### Feedback Requested

Please review.
