### PR TITLE
Formatting updates for _since in user guides

### DIFF
--- a/production/technical_userguide.md
+++ b/production/technical_userguide.md
@@ -691,11 +691,9 @@ The `_since` parameter grants you the ability to apply a date parameter to your 
 
 For more information on `_since`, please consult the [FHIR standard on query parameters](https://hl7.org/Fhir/uv/bulkdata/export/index.html#query-parameters){:target="_blank"}.
 
-#### Usage
-There are a couple of helpful points to keep in mind when using `_since`.
 
-#### Before Using `_since` 
-Before using `_since` for the first time, we recommend that you retrieve all historical data. Once you have retrieved your historical data and begun using `_since`, you should use [`transactionTime`](https://hl7.org/Fhir/uv/bulkdata/export/index.html#response---complete-status){:target="_blank"} from your last bulk data request as the date for following `_since` calls.
+#### Request Historical Data Before Using `_since` 
+Before using `_since` for the first time, we recommend that you run an unfiltered request (without using `_since`) to all resource types on the `/Patient` endpoint in order to retrieve all historical data. You only need to do this once. On subsequent calls you can begin using `_since`, with the [`transactionTime`](https://hl7.org/Fhir/uv/bulkdata/export/index.html#response---complete-status){:target="_blank"} from your last bulk data request set as the `_since` date.
 
 **Note: Due to limitations in the Beneficiary FHIR Data (BFD) Server, data from before 02-12-2020 is marked with the arbitrary [lastUpdated](https://www.hl7.org/fhir/search.html#lastUpdated){:target="_blank"} date of 01-01-2020. If you input dates between 01-01-2020 and 02-11-2020 in the `_since` parameter, you will receive all historical data for your beneficiaries. Data loads from 02-12-2020 onwards have been marked with accurate dates.**
 
@@ -711,7 +709,7 @@ More information about the FHIR _instant_ format can be found in the [FHIR Datat
 #### Usage Examples
 See the [Authentication and Authorization section](/production/technical-user-guide/#authentication-and-authorization){:target="_blank"} above to obtain the API token needed before requesting data from any of the BCDA bulk data endpoints. 
 
-Here are examples of how to initiate an export job using `_since` to augment `/Patient`. We are seeking data from the `/Patient` endpoint for the Patient resource type since 8PM EST on February 13th, 2020. The steps and format would work similarly for other endpoints and resource types.
+In the example below, we are seeking data from the `/Patient` endpoint for the Patient resource type since 8PM EST on February 13th, 2020. The steps and format would work similarly for other endpoints and resource types.
 
 **Request**
 
@@ -732,9 +730,9 @@ curl -X GET "https://api.bcda.cms.gov/api/v1/Patient/$export?_type=Patient?_sinc
 
 **cURL Commands for Subsequent Steps**
 
-Instructions for checking the status of the export job and retrieving NDJSON output file(s) can be found in previous sections. See _3. Checking the status of the export job_ and _4. Retrieving NDJSON output file(s)_.
+Instructions for checking the status of the export job and retrieving NDJSON output file(s) can be found in previous sections on [checking the status of the export job](#3-check-the-status-of-the-export-job) and [retrieving NDJSON output file(s)](#4-retrieve-ndjson-output-files).
 
-For ease of use, we have listed the `Curl` commands below. The job ID (48) and file name for the NDJSON file (`4e2cd98c-4746-4138-872b-24778c000b02.ndjson`) will be different for your job.
+For ease of use, we have listed the `Curl` commands for these operations below. The job ID (48) and file name for the NDJSON file (`4e2cd98c-4746-4138-872b-24778c000b02.ndjson`) will be different for your job.
 
 **Check the status of the export job:**
 ```

--- a/production/user_guide.md
+++ b/production/user_guide.md
@@ -230,9 +230,11 @@ After retrieving your historical data, it may be helpful to use the date of your
 
 #### b. Input a date in the correct format.
 
+First, click “Try it Out” in the Swagger section for `GET /api/v1/Patient/export`. 
+
 <img class="ug-img" src="/assets/img/since_1.svg" alt="" />
 
-First, click “Try it Out” in the Swagger section for `_since`. Then, enter your desired date into the dialog box labeled "`_since` (Optional)". Dates and times submitted in `_since` must adhere to a specific format for the server to understand. That format is the FHIR _instant_ format (`YYYY-MM-DDThh:mm:ss.sss+zz:zz`).
+Then, enter your desired date into the dialog box labeled "`_since` (Optional)". Dates and times submitted in `_since` must adhere to a specific format for the server to understand. That format is the FHIR _instant_ format (`YYYY-MM-DDThh:mm:ss.sss+zz:zz`).
 
 <img class="ug-img" src="/assets/img/since_2.svg" alt="" />
 
@@ -254,7 +256,7 @@ If you’d like to use the command line or implement this API call in code, look
 
 Not far below that, you can see the response: an `HTTP 202 Accepted` giving a link in the `content-location` header for status information on your job.
 
-<img class="ug-img" src="/assets/img/since_3.svg" alt="" />
+<img class="ug-img" src="/assets/img/since_3.svg" alt="Swagger: 'curl' examples are given in full in the Advanced User Guide" />
 
 #### d. Getting your data
 

--- a/production/user_guide.md
+++ b/production/user_guide.md
@@ -210,7 +210,7 @@ Once you’ve downloaded the file, you’ll want to know what to do with the dat
 
 ### Filtering your requests using `_since`
 
-The `_since` parameter lets you filter your bulk data requests by the date when it was updated. This means that instead of receiving all your historical data each time you request data from the API, you will instead be able to enter the date since you last requested data. The API will return data updated between your `_since` input date and the present. The `since` parameter can be used with requests for all resource types.
+The `_since` parameter lets you filter your bulk data requests by the date when the data was updated. This means that instead of receiving all your historical data each time you request data from the API, you will instead be able to enter the date since you last requested data and receive only data updated between your `_since` input date and the present. The `since` parameter can be used with requests for all resource types.
 
 Before using `_since` for the first time, pull your historical data. Using the `_since` parameter subsequently comprises three steps:
 
@@ -226,7 +226,7 @@ See [Making Your First Requests for Data](/production/user-guide/#making-your-fi
 
 After retrieving your historical data, it may be helpful to use the date of your most recent bulk data request for subsequent data pulls using the `_since` parameter. You may retrieve this date by viewing the [_transactionTime_](https://hl7.org/Fhir/uv/bulkdata/export/index.html#response---complete-status){:target="_blank"} from your last bulk data request.
 
-**Note: Do not input dates before 02-12-2020 into `_since`. Limitations of the Beneficiary FHIR Data (BFD) Server prevent data before 02-12-2020 from being tagged correctly.  For more details, see the [Advanced User Guide](/production/technical-user-guide/#filtering-your-data-with-_since).**
+**Note: Do not input dates before 02-12-2020 into `_since`. Limitations of the Beneficiary FHIR Data (BFD) Server prevent data before 02-12-2020 from being tagged correctly. For more details, see the [Advanced User Guide](/production/technical-user-guide/#filtering-your-data-with-_since).**
 
 #### b. Input a date in the correct format.
 
@@ -248,17 +248,17 @@ More information about the FHIR instant format can be found on the [FHIR Datatyp
 
 #### c. Start the job to acquire data from that endpoint
 
-To start the job, click Execute.
+To start the job, click `Execute`.
 
 If you’d like to use the command line or implement this API call in code, look in the `Curl` section for the request you just made. 
 
-Not far below that, you can see the response: an `HTTP 202 Accepted` giving a link in the content-location header for status information on your job.
+Not far below that, you can see the response: an `HTTP 202 Accepted` giving a link in the `content-location` header for status information on your job.
 
 <img class="ug-img" src="/assets/img/since_3.svg" alt="" />
 
 #### d. Getting your data
 
-Retrieving your files after a filtered bulk data request works similarily to making an unfiltered request. See the instructions for _5. Getting your data_ above
+Follow the previous instructions on for [getting your data from an unfiltered request](#5-getting-your-data) to retrieve your files after a filtered bulk data request. 
 
 ## <a name="frequently-asked-questions"></a>Frequently asked questions about making requests
 

--- a/sandbox/technical_user_guide.md
+++ b/sandbox/technical_user_guide.md
@@ -760,9 +760,6 @@ The `_since` parameter grants you the ability to apply a date parameter to your 
 
 For more information on `_since`, please consult the [FHIR standard on query parameters](https://hl7.org/Fhir/uv/bulkdata/export/index.html#query-parameters){:target="_blank"}.
 
-#### Usage
-There are a couple of helpful points to keep in mind when using `_since`.
-
 #### Date and Timezone Formatting
 Dates and times submitted in `_since` must be listed in the FHIR _instant_ format (`YYYY-MM-DDThh:mm:sss+zz:zz`).
 
@@ -775,7 +772,7 @@ More information about the FHIR _instant_ format can be found in the [FHIR Datat
 #### Usage Examples
 See the [Authentication and Authorization section](/sandbox/technical-user-guide/#authentication-and-authorization){:target="_blank"} above to obtain the API token needed before requesting data from any of the BCDA bulk data endpoints. 
 
-Here are examples of how to initiate an export job using `_since` to augment `/Patient`. We are seeking data from the `/Patient` endpoint for the Patient resource type since 8PM EST on February 13th, 2020. The steps and format would work similarly for other endpoints and resource types.
+In the example below, we are seeking data from the `/Patient` endpoint for the Patient resource type since 8PM EST on February 13th, 2020. The steps and format would work similarly for other endpoints and resource types.
 
 **Request**
 
@@ -794,11 +791,11 @@ curl -X GET "https://sandbox.bcda.cms.gov/api/v1/Patient/$export?_type=Patient?_
 -H 'Prefer: respond-async'
 ```
 
-**cURL Commands for Subsequent Steps**
+**cURL Commands for subsequent steps**
 
-Instructions for checking the status of the export job and retrieving NDJSON output file(s) can be found in previous sections. See _3. Checking the status of the export job_ and _4. Retrieving NDJSON output file(s)_.
+Instructions for checking the status of the export job and retrieving NDJSON output file(s) can be found in previous sections on [checking the status of the export job](#3-check-the-status-of-the-export-job) and [retrieving NDJSON output file(s)](#4-retrieve-ndjson-output-files).
 
-For ease of use, we have listed the `Curl` commands below. The job ID (48) and file name for the NDJSON file (`4e2cd98c-4746-4138-872b-24778c000b02.ndjson`) will be different for your job.
+For ease of use, we have listed the `Curl` commands for these operations below. The job ID (48) and file name for the NDJSON file (`4e2cd98c-4746-4138-872b-24778c000b02.ndjson`) will be different for your job.
 
 **Check the status of the export job:**
 ```

--- a/sandbox/user_guide.md
+++ b/sandbox/user_guide.md
@@ -276,7 +276,7 @@ Once the job is completed, you will receive a `HTTP 200 Complete` response, whic
 
 <img class="ug-img" src="/assets/img/swagger_walkthrough_10.svg" alt="Swagger: copy the file name: the part of the URL after the last '/'" />
 
-To retrieve your data, open the `GET /data/{jobId}/{filename.ndjson}` endpoint. Copy the `jobId` into the `jobId` field, and the last string of the URL received in the previous step (highlighted in green and dashed lines above) into the `filename` field, then hit `Execute`.
+To retrieve your data, open the `GET /data/{jobId}/{filename.ndjson}` endpoint. Copy the `jobId` into the `jobId` field, and the last string of the URL received in the previous step (underlined above) into the `filename` field, then hit `Execute`.
 
 <img class="ug-img" src="/assets/img/swagger_walkthrough_11.svg" alt="" />
 
@@ -302,12 +302,13 @@ Using the `_since` parameter comprises three steps:
 
 #### a. Input a date in the correct format
 
-<img class="ug-img" src="/assets/img/since_1.svg" alt="" />
+First, click “Try it Out” in the Swagger section for `GET /api/v1/Patient/export`. 
 
-First, click “Try it Out” in the Swagger section for `_since`. Then, enter your desired date into the dialog box labeled "`_since` (Optional)". Dates and times submitted in `_since` must adhere to a specific format for the server to understand. That format is the FHIR _instant_ format (`YYYY-MM-DDThh:mm:ss.sss+zz:zz`).
+<img class="ug-img" src="/assets/img/since_1.svg" alt="Swagger: navigate to the /Patient endpoint and click Try it Out" />
+
+Then, enter your desired date into the dialog box labeled "`_since` (Optional)". Dates and times submitted in `_since` must adhere to a specific format for the server to understand. That format is the FHIR _instant_ format (`YYYY-MM-DDThh:mm:ss.sss+zz:zz`).
 
 <img class="ug-img" src="/assets/img/since_2.svg" alt="" />
-
 
 The example below demonstrates how to convert a date/time combination into the FHIR format.
 
@@ -327,7 +328,7 @@ If you’d like to use the command line or implement this API call in code, look
 
 Not far below that, you can see the response: an `HTTP 202 Accepted` giving a link in the `content-location` header for status information on your job.
 
-<img class="ug-img" src="/assets/img/since_3.svg" alt="" />
+<img class="ug-img" src="/assets/img/since_3.svg" alt="Swagger: cURL commands are listed in full in the Advanced User Guide" />
 
 #### c. Getting your data
 

--- a/sandbox/user_guide.md
+++ b/sandbox/user_guide.md
@@ -220,7 +220,7 @@ Within the `Patient` endpoint, you can make requests for up to three resource ty
 
 ### 4. Making your first request for beneficiary data
 
-To get any bulk beneficiary data, you must first be authorized with BCDA. Make sure you’ve followed the steps above for [Setting up your credentials in Swagger](#setting-up-your-credentials-in-swagger) before moving forward.
+To get any bulk beneficiary data, you must first be authenticated with BCDA. Make sure you’ve followed the steps above for [Setting up your credentials in Swagger](#setting-up-your-credentials-in-swagger) before moving forward.
 
 Retrieving beneficiary data comprises two steps:
 
@@ -292,15 +292,15 @@ Once you’ve downloaded the file, you’ll want to know what to do with the dat
 
 ### Filtering your requests using `_since`
 
-The `_since` parameter lets you filter your bulk data requests by the date when it was updated. This means that instead of receiving all your historical data each time you request data from the API, you will instead be able to enter the date since you last requested data. The API will return data updated between your `_since` input date and the present. The `since` parameter can be used with requests for all resource types.
+The `_since` parameter lets you filter your bulk data requests by the date when the data was updated. This means that instead of receiving all your historical data each time you request data from the API, you will instead be able to enter the date since you last requested data. The API will return data updated between your `_since` input date and the present. The `since` parameter can be used with requests for all resource types.
 
 Using the `_since` parameter comprises three steps:
 
-1. Input a date in the correct format.
-2. Start the job to acquire data from an endpoint.
-3. Retrieve data via a job request.
+1. Input a date in the correct format
+2. Start the job to acquire data from an endpoint
+3. Retrieve data via a job request
 
-#### a. Input a date in the correct format.
+#### a. Input a date in the correct format
 
 <img class="ug-img" src="/assets/img/since_1.svg" alt="" />
 
@@ -321,14 +321,14 @@ More information about the FHIR instant format can be found on the [FHIR Datatyp
 
 #### b. Start the job to acquire data from that endpoint
 
-To start the job, click Execute.
+To start the job, click `Execute`.
 
 If you’d like to use the command line or implement this API call in code, look in the `Curl` section for the request you just made. 
 
-Not far below that, you can see the response: an `HTTP 202 Accepted` giving a link in the content-location header for status information on your job.
+Not far below that, you can see the response: an `HTTP 202 Accepted` giving a link in the `content-location` header for status information on your job.
 
 <img class="ug-img" src="/assets/img/since_3.svg" alt="" />
 
 #### c. Getting your data
 
-Retrieving your files after a filtered bulk data request works similarily to making an unfiltered request. See the instructions for _5. Getting your data_ above
+Follow the previous instructions on for [getting your data from an unfiltered request](#5-getting-your-data) to retrieve your files after a filtered bulk data request. 


### PR DESCRIPTION
Fixes typos, updates anchor links, and standardizes image locations and formatting in sections discussing the _since parameter.

### Proposed Changes

* Add anchor links to previous sections of the user guides when those sections are referenced in the _since instructions
* Production user guides: minor edits for clarity on requesting historical data before using _since parameter
* Swagger walkthroughs: add alt-text to Swagger images referencing cURL commands


### Security Implications

None


### Feedback Requested

* Confirm language changes made language better, not worse
* Confirm anchor links work
