### PR TITLE
Add AB2D Information to BCDA Static Site

### DIFF
--- a/index.md
+++ b/index.md
@@ -79,7 +79,7 @@ Representatives of Shared Savings Program ACOs are now invited to express their 
    BCDA is one member of a suite of FHIR APIs provided by CMS, which work together to provide claims data that enables higher-quality patient care.
 
 ### [Claims Data to Part D Sponsors API (AB2D):](https://ab2d.cms.gov){:target="_blank"}
-   * Provides FHIR-formatted bulk claims data to stand-alone Presciption Drug Sponsors for their enrollees.
+   * Provides FHIR-formatted bulk claims data to stand-alone Prescription Drug Sponsors for their enrollees.
 
 ### [Blue Button 2.0:](https://bluebutton.cms.gov){:target="_blank"}
    * Provides FHIR-formatted data for **one** individual Medicare beneficiary at a time, to registered applications with beneficiary authorization.

--- a/index.md
+++ b/index.md
@@ -78,6 +78,9 @@ Representatives of Shared Savings Program ACOs are now invited to express their 
 
    BCDA is one member of a suite of FHIR APIs provided by CMS, which work together to provide claims data that enables higher-quality patient care.
 
+### [Claims Data to Part D Sponsors API (AB2D):](https://ab2d.cms.gov){:target="_blank"}
+   * Provides FHIR-formatted bulk claims data to stand-alone Presciption Drug Sponsors for their enrollees.
+
 ### [Blue Button 2.0:](https://bluebutton.cms.gov){:target="_blank"}
    * Provides FHIR-formatted data for **one** individual Medicare beneficiary at a time, to registered applications with beneficiary authorization.
 


### PR DESCRIPTION
### Introduces AB2D Information to BCDA Static Site

The AB2D project went live with their website today, so we should include a reference to it on our static site.


### Change Details

- Added AB2D information to `FHIR APIs at CMS` section

### Security Implications


- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change


### Acceptance Validation

Pushed feature branch to `stage` and validated the content.

### Feedback Requested

Please review.  Do we want AB2D to be first in the list, due to alphabetic order?
