### PR TITLE
BCDA-3368 Added Site Version to Static Site

### DIFF
--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -4,4 +4,4 @@ ENV BUNDLE_PATH=$GEM_HOME
 WORKDIR /bcda-site-static
 COPY . .
 RUN ["bundle", "install"]
-ENTRYPOINT ["bundle", "exec", "jekyll", "build"]
+ENTRYPOINT ["bundle", "exec", "jekyll", "build", "--config", "_config.yml,_version_config.yml"]

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,6 +2,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="version" content="{{ site.version }}">
 	<!-- Metadata for Twitter -->
 	<meta name="twitter:title" content="{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}" />
 	<meta name="twitter:description" content="{{ page.excerpt | default: site.description | strip_html | normalize_whitespace | truncate: 160 | escape }}" />

--- a/_version_config.yml
+++ b/_version_config.yml
@@ -1,0 +1,1 @@
+version: latest


### PR DESCRIPTION
### Fixes [BCDA-3368](https://jira.cms.gov/browse/BCDA-3368)

Adding the release number or branch name to the static site so developers can quickly determine which version of the page they are currently looking at. Related to https://github.com/CMSgov/bcda-ops/pull/508

### Proposed Changes

* added a new `meta` tag to the site header that pulls its content from the site configuration
* added a new file called "_version_config.yml" that will have the site's version configuration
* included the new config file in the build command for jekyll

### Change Details

<!-- Add detailed discussion of changes here: -->

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

- [x] no PHI/PII is affected by this change

<!-- If yes, provide what PHI/PII is affected by this change -->

### Acceptance Validation

Deployed to staging environment with jekyll

<img width="649" alt="Screen Shot 2020-07-30 at 9 18 12 AM" src="https://user-images.githubusercontent.com/8621390/88928068-5a22df80-d246-11ea-82da-b3ef5f20d791.png">


### Feedback Requested

Should the default for version be "latest" if for some reason the version is not updated when it is deployed?
