### PR TITLE
Update OpenAPI links

### DIFF
--- a/production/technical_userguide.md
+++ b/production/technical_userguide.md
@@ -113,7 +113,7 @@ The examples below include [cURL](https://curl.haxx.se){:target="_blank"} comman
 ## Examples
 
 ### Generate Client Code
-An OpenAPI v3 JSON schema file, which represents the service capabilities of the API, can be accessed at [https://api.bcda.cms.gov/api/v1/swagger/openapi.json](https://api.bcda.cms.gov/api/v1/swagger/openapi.json){:target="_blank"}.  This file can be used to generate client code to interact with BCDA.  There are various tools that can be used to generate client code from an OpenAPI v3 JSON schema file; one of which is Swagger Editor ([https://editor.swagger.io/](https://editor.swagger.io/){:target="_blank"}), which can generate code in dozens of different programming languages and also produces a `README` describing usage of the newly generated client code.
+An OpenAPI v3 JSON schema file, which represents the service capabilities of the API, can be accessed from [our Swagger page](https://api.bcda.cms.gov/api/v1/swagger/openapi.json){:target="_blank"}.  This file can be used to generate client code to interact with BCDA.  There are various tools that can be used to generate client code from an OpenAPI v3 JSON schema file; one of which is [Swagger Editor](https://editor.swagger.io/){:target="_blank"}, which can generate code in dozens of different programming languages and also produces a `README` describing usage of the newly generated client code.
 
 ### Sample Code
 BCDA provides [test code written in Golang](https://github.com/CMSgov/bcda-app/blob/master/test/smoke_test/bcda_client.go){:target="_blank"} in our GitHub instance that you can use to set up your system to work with the API.

--- a/sandbox/technical_user_guide.md
+++ b/sandbox/technical_user_guide.md
@@ -181,7 +181,7 @@ The examples below include [cURL](https://curl.haxx.se/){:target="_blank"} comma
 ## Examples
 
 ### Generate Client Code
-An OpenAPI v3 JSON schema file, which represents the service capabilities of the API, can be accessed at [https://sandbox.bcda.cms.gov/api/v1/swagger/openapi.json](https://sandbox.bcda.cms.gov/api/v1/swagger/openapi.json){:target="_blank"}.  This file can be used to generate client code to interact with BCDA.  There are various tools that can be used to generate client code from an OpenAPI v3 JSON schema file; one of which is Swagger Editor ([https://editor.swagger.io/](https://editor.swagger.io/){:target="_blank"}), which can generate code in dozens of different programming languages and also produces a `README` describing usage of the newly generated client code.
+An OpenAPI v3 JSON schema file, which represents the service capabilities of the API, can be accessed from [our Swagger page](https://sandbox.bcda.cms.gov/api/v1/swagger/openapi.json){:target="_blank"}.  This file can be used to generate client code to interact with BCDA.  There are various tools that can be used to generate client code from an OpenAPI v3 JSON schema file; one of which is [Swagger Editor](https://editor.swagger.io/){:target="_blank"}, which can generate code in dozens of different programming languages and also produces a `README` describing usage of the newly generated client code.
 
 ### Sample Code
 BCDA provides [test code written in Golang](https://github.com/CMSgov/bcda-app/blob/master/test/smoke_test/bcda_client.go){:target="_blank"} in our GitHub instance that you can use to set up your system to work with the API.


### PR DESCRIPTION
### Fixes Links in OpenAPI Section

Instead of listing the entire OpenAPI-related links, lets embed the links into the text (consistent with other areas of text on the site).

### Change Details

- Fixed links in OpenAPI section

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change


### Acceptance Validation

Before:

<img width="705" alt="Screen Shot 2020-09-03 at 1 23 36 PM" src="https://user-images.githubusercontent.com/37818548/92147508-3de80480-ede9-11ea-9079-dbb618906d80.png">


After:

<img width="646" alt="Screen Shot 2020-09-03 at 1 23 12 PM" src="https://user-images.githubusercontent.com/37818548/92147515-42acb880-ede9-11ea-85c3-9d7ae41bfc2f.png">



### Feedback Requested

Please review.
