### PR TITLE
Efrankle/bcda-3754 - fix _since syntax in technical guides

### DIFF
--- a/production/technical_userguide.md
+++ b/production/technical_userguide.md
@@ -419,7 +419,7 @@ See [Authentication and Authorization](https://bcda.cms.gov/production/technical
 
 **Request**
 
-`GET /api/v1/Patient/$export?_type=Patient?_since=2020-02-13T08:00:00.000-05:00`
+`GET /api/v1/Patient/$export?_type=Patient&_since=2020-02-13T08:00:00.000-05:00`
 
 **Headers**
 
@@ -430,7 +430,7 @@ See [Authentication and Authorization](https://bcda.cms.gov/production/technical
 **`cURL` command**
 
 ```
-curl -X GET "https://api.bcda.cms.gov/api/v1/Patient/$export?_type=Patient?_since=2020-02-13T08:00:00.000-05:00
+curl -X GET "https://api.bcda.cms.gov/api/v1/Patient/$export?_type=Patient&_since=2020-02-13T08:00:00.000-05:00
 -H 'Authorization: Bearer {token}' \
 -H 'Accept: application/fhir+json' \
 -H 'Prefer: respond-async'
@@ -480,7 +480,7 @@ See [Authentication and Authorization](https://bcda.cms.gov/production/technical
 
 **Request**
 
-`GET /api/v1/Group/all/$export?_type=Patient?_since=2020-02-13T08:00:00.000-05:00`
+`GET /api/v1/Group/all/$export?_type=Patient&_since=2020-02-13T08:00:00.000-05:00`
 
 To start a data export job for filtered data from existing beneficiaries since 8PM EST on February 13th, 2020 and all data for newly assigned beneficiaries that month, a `GET` request is made to the `/Group` endpoint. The `groupID` of “`all`” is provided as well as a `_since` date in the correct format. An access token as well as _Accept_ and _Prefer_ headers are required.
 The dollar sign (`$`) before the word “export” in the URL indicates that the endpoint is an action rather than a resource. The format is defined by the [FHIR Bulk Data Export spec](https://github.com/HL7/bulk-data/blob/master/spec/export/index.md){:target="_blank"}.
@@ -494,7 +494,7 @@ The dollar sign (`$`) before the word “export” in the URL indicates that the
 **`cURL` command**
 
 ```
-curl -X GET "https://api.bcda.cms.gov/api/v1/Group/all/$export?_type=Patient?_since=2020-02-13T08:00:00.000-05:00
+curl -X GET "https://api.bcda.cms.gov/api/v1/Group/all/$export?_type=Patient&_since=2020-02-13T08:00:00.000-05:00
 -H 'Authorization: Bearer {token}' \
 -H 'Accept: application/fhir+json' \
 -H 'Prefer: respond-async'

--- a/sandbox/technical_user_guide.md
+++ b/sandbox/technical_user_guide.md
@@ -486,7 +486,7 @@ See [Authentication and Authorization](#authentication-and-authorization){:targe
 
 **Request**
 
-`GET /api/v1/Patient/$export?_type=Patient?_since=2020-02-13T08:00:00.000-05:00`
+`GET /api/v1/Patient/$export?_type=Patient&_since=2020-02-13T08:00:00.000-05:00`
 
 **Headers**
 
@@ -497,7 +497,7 @@ See [Authentication and Authorization](#authentication-and-authorization){:targe
 **`cURL` command**
 
 ```
-curl -X GET "https://sandbox.bcda.cms.gov/api/v1/Patient/$export?_type=Patient?_since=2020-02-13T08:00:00.000-05:00
+curl -X GET "https://sandbox.bcda.cms.gov/api/v1/Patient/$export?_type=Patient&_since=2020-02-13T08:00:00.000-05:00
 -H 'Authorization: Bearer {token}' \
 -H 'Accept: application/fhir+json' \
 -H 'Prefer: respond-async'
@@ -547,7 +547,7 @@ See [Authentication and Authorization](#authentication-and-authorization){:targe
 
 **Request**
 
-`GET /api/v1/Group/all/$export?_type=Patient?_since=2020-02-13T08:00:00.000-05:00`
+`GET /api/v1/Group/all/$export?_type=Patient&_since=2020-02-13T08:00:00.000-05:00`
 
 To start a data export job for filtered data from existing beneficiaries since 8PM EST on February 13th, 2020 and all data for newly assigned beneficiaries that month, a `GET` request is made to the `/Group` endpoint. The `groupID` of “`all`” is provided as well as a `_since` date in the correct format. An access token as well as _Accept_ and _Prefer_ headers are required.
 The dollar sign (`$`) before the word “export” in the URL indicates that the endpoint is an action rather than a resource. The format is defined by the [FHIR Bulk Data Export spec](https://github.com/HL7/bulk-data/blob/master/spec/export/index.md){:target="_blank"}.
@@ -561,7 +561,7 @@ The dollar sign (`$`) before the word “export” in the URL indicates that the
 **`cURL` command**
 
 ```
-curl -X GET "https://sandbox.bcda.cms.gov/api/v1/Group/all/$export?_type=Patient?_since=2020-02-13T08:00:00.000-05:00
+curl -X GET "https://sandbox.bcda.cms.gov/api/v1/Group/all/$export?_type=Patient&_since=2020-02-13T08:00:00.000-05:00
 -H 'Authorization: Bearer {token}' \
 -H 'Accept: application/fhir+json' \
 -H 'Prefer: respond-async'


### PR DESCRIPTION


### Fixes [BCDA-3754](https://jira.cms.gov/browse/BCDA-3754)

A google group question revealed an error in how we presented the syntax for making a filtered request using _since.

### Proposed Changes

Replace incorrect `?_since` syntax when _since is the second query being added with the correct `&_since` syntax.

### Change Details

Code has been corrected in all eight locations where the wrong code had been populated.

### Security Implications

None


### Feedback Requested

Please make sure I didn't break anything I shouldn't have or overcorrect things that were already accurate.
