### PR TITLE
BCDA-3922 - Content changes to Getting Started page

### DIFF
--- a/_includes/guide/fhir_types.html
+++ b/_includes/guide/fhir_types.html
@@ -1,3 +1,3 @@
 <p>
-  A resource is an object with a type, associated data, relationships to other resources, and a set of methods that operate on it. The BCDA API utilizes three resource types under the FHIR specification (LINK).
+  A resource is an object with a type, associated data, relationships to other resources, and a set of methods that operate on it. The BCDA API utilizes three resource types under the <a href="https://www.hl7.org/fhir/" target="_blank">FHIR specification</a>.
 </p>

--- a/_includes/guide/try_the_api.html
+++ b/_includes/guide/try_the_api.html
@@ -19,7 +19,7 @@
 <p>
 	Client ID:
 	09869a7f-46ce-4908-a914-6129d080a2ae
-
+	<br />
 	Client Secret:
 	64916fe96f71adc79c5735e49f4e72f18ff941d0dd62cf43ee1ae0857e204f173ba10e4250c12c48
 </p>
@@ -27,10 +27,9 @@
 	cURL Command to Submit Credentials for an Access Token
 </H4>
 <p>
-	curl -d '' -X POST "https://api.bcda.cms.gov/auth/token" --user <client secret>
-<p>
+	curl -d '' -X POST "https://api.bcda.cms.gov/auth/token" --user {Client ID:Client Secret} \
+	<br />
 	-H "accept: application/json"
-</p>
 </p>
 <H4>
 	Authentication Response
@@ -47,16 +46,13 @@
 	Sample cURL Command
 </H4>
 <p>
-	curl -X GET "https://api.bcda.cms.gov/api/v1/Patient/$export"
-<p>
-	-H "accept: application/fhir+json"
-</p>
-<p>
-	-H "Prefer: respond-async"
-</p>
-<p>
-	-H "Authorization: Bearer {token}"`
-</p>
+	curl -X GET "https://api.bcda.cms.gov/api/v1/Patient/$export" \
+	<br />
+	-H "accept: application/fhir+json" \
+	<br />
+	-H "Prefer: respond-async" \
+	<br />
+	-H "Authorization: Bearer {token}"
 </p>
 
 <H3>
@@ -67,12 +63,10 @@
 </H4>
 <p>
 	curl -X GET "https://api.bcda.cms.gov/api/v1/jobs/42" \
-<p>
+	<br />
 	-H "accept: application/fhir+json" \
-</p>
-<p>
+	<br />
 	-H "Authorization: Bearer {token}"
-</p>
 </p>
 
 <H3>
@@ -83,10 +77,8 @@
 </H4>
 <p>
 	curl https://api.bcda.cms.gov/data/42/afd22dfa-c239-4063-8882-eb2712f9f638.ndjson \
-<p>
-	-H 'Authorization: Bearer {token}'
-</p>
-<p>
+	<br />
+	-H 'Authorization: Bearer {token}' \
+	<br />
 	-H ‘Accept-Encoding: gzip’
-</p>
 </p>

--- a/guide.html
+++ b/guide.html
@@ -19,7 +19,7 @@ layout: default
       <ul class="ds-c-vertical-nav sidenav">
         <li class="ds-c-vertical-nav__item">
           <a
-            class="ds-c-vertical-nav__label ds-c-vertical-nav__label--current"
+            class="ds-c-vertical-nav__label"
             href="#what-is-an-api"
           >
             What is an API
@@ -27,7 +27,7 @@ layout: default
         </li>
         <li class="ds-c-vertical-nav__item">
           <a
-            class="ds-c-vertical-nav__label ds-c-vertical-nav__label--current"
+            class="ds-c-vertical-nav__label"
             href="#what-is-fhir"
           >
             What is FHIR
@@ -35,7 +35,7 @@ layout: default
         </li>
         <li class="ds-c-vertical-nav__item">
           <a
-            class="ds-c-vertical-nav__label ds-c-vertical-nav__label--current"
+            class="ds-c-vertical-nav__label"
             href="#fhir-endpoints"
           >
             BCDA's Bulk FHIR Endpoints
@@ -43,7 +43,7 @@ layout: default
           <ul class="ds-c-vertical-nav__subnav">
             <li class="ds-c-vertical-nav__subnav">
               <a
-                class="ds-c-vertical-nav__label ds-c-vertical-nav__label--current"
+                class="ds-c-vertical-nav__label"
                 href="#patient-endpoint"
               >
                 /Patient Endpoint
@@ -51,7 +51,7 @@ layout: default
             </li>
             <li class="ds-c-vertical-nav__subnav">
               <a
-                class="ds-c-vertical-nav__label ds-c-vertical-nav__label--current"
+                class="ds-c-vertical-nav__label"
                 href="#group-endpoint"
               >
                 /Group Endpoint
@@ -61,7 +61,7 @@ layout: default
         </li>
         <li class="ds-c-vertical-nav__item">
           <a
-            class="ds-c-vertical-nav__label ds-c-vertical-nav__label--current"
+            class="ds-c-vertical-nav__label"
             href="#fhir-types"
           >
             FHIR Resource Types
@@ -69,7 +69,7 @@ layout: default
           <ul class="ds-c-vertical-nav__subnav">
             <li class="ds-c-vertical-nav__subnav">
               <a
-                class="ds-c-vertical-nav__label ds-c-vertical-nav__label--current"
+                class="ds-c-vertical-nav__label"
                 href="#eob-resource"
               >
                 Explanation of Benefit (EOB)
@@ -77,7 +77,7 @@ layout: default
             </li>
             <li class="ds-c-vertical-nav__subnav">
               <a
-                class="ds-c-vertical-nav__label ds-c-vertical-nav__label--current"
+                class="ds-c-vertical-nav__label"
                 href="#patient-resource"
               >
                 Patient
@@ -85,7 +85,7 @@ layout: default
             </li>
             <li class="ds-c-vertical-nav__subnav">
               <a
-                class="ds-c-vertical-nav__label ds-c-vertical-nav__label--current"
+                class="ds-c-vertical-nav__label"
                 href="#coverage-resource"
               >
                 Coverage
@@ -95,7 +95,7 @@ layout: default
         </li>
         <li class="ds-c-vertical-nav__item">
           <a
-            class="ds-c-vertical-nav__label ds-c-vertical-nav__label--current"
+            class="ds-c-vertical-nav__label"
             href="#sandbox"
           >
             Sandbox
@@ -103,7 +103,7 @@ layout: default
         </li>
         <li class="ds-c-vertical-nav__item">
           <a
-            class="ds-c-vertical-nav__label ds-c-vertical-nav__label--current"
+            class="ds-c-vertical-nav__label"
             href="#try-the-api"
           >
             Try the API


### PR DESCRIPTION
### Part of [BCDA-3922](https://jira.cms.gov/browse/BCDA-3922)

Styling/Content changes related to Getting Started page.

### Change Details

1. Remove "current" label on vertical nav bar entries. We had this property set which made them all appear to be "current".

Before: 
![Screen Shot 2020-11-17 at 3 49 23 PM](https://user-images.githubusercontent.com/21049223/99460096-7a0d0a80-28ec-11eb-91b8-0c6b619a3de3.png)
After:
![Screen Shot 2020-11-17 at 3 50 25 PM](https://user-images.githubusercontent.com/21049223/99460195-aaed3f80-28ec-11eb-8d9c-7a817480bcbb.png)

2. Update formatting on cURL statements (new line, line continuation, etc.)

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation

1. Approval from H-Team