### PR TITLE
Remove filler language on Try the API

### DIFF
--- a/_includes/guide/try_the_api.html
+++ b/_includes/guide/try_the_api.html
@@ -3,9 +3,9 @@
 </p>
 <ol>
 	<li>Obtain an access token: How do I show the API that I can receive this data?</li>
-	<li>Start a job to acquire data: Start making my pie.</li>
-	<li>Check the job status: Peek at the pie in the oven.</li>
-	<li>Download the data: Pull the pie out of the oven.</li>
+	<li>Start a job to acquire data: How do I tell the API to get my data?</li>
+	<li>Check the job status: How do I check when the API is done getting my data?</li>
+	<li>Download the data: How do I get my data once it is done?</li>
 </ol>
 <p>
 	All requests for BCDA data follow this four step process, as do other APIs following the Bulk FHIR specifications.


### PR DESCRIPTION
Fixing language on the Try the API page by getting rid of filler language.

### Proposed Changes

- Changed four list items in the Try the API section

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [X ] no PHI/PII is affected by this change


