### PR TITLE
Remove "Reduce Burden" section from value prop

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,29 +38,21 @@ id: home
         </div>
       </div>
       <div class="ds-l-row ds-u-margin-top--5">
-        <div class="ds-l-sm-col--12 ds-l-md-col--12 ds-l-lg-col--3 benefit-prop">
+        <div class="ds-l-sm-col--12 ds-l-md-col--12 ds-l-lg-col--4 benefit-prop">
           <img src="/assets/img/homepage/ValueProp_1.svg" alt="Improve">
           <div class="benefit-prop__body ds-u-padding-y--1">
             <div class="ds-u-font-size--lead ds-u-font-weight--semibold">Supplement Insights</div>
             <p>BCDA supplements ACOs' insight into their assigned beneficiary populations with Medicare claims data.</p>
           </div>
         </div>
-        <div class="ds-l-sm-col--12 ds-l-md-col--12 ds-l-lg-col--3 benefit-prop">
-          <img src="/assets/img/homepage/ValueProp_2.svg" alt="Reduce Labor">
-          <div class="benefit-prop__body ds-u-padding-y--1">
-            <div class="ds-u-font-size--lead ds-u-font-weight--semibold">Reduce Burden</div>
-            <p>BCDA removes the burden of providing a beneficiary roster to receive Medicare claims data. CMS already has it; BCDA uses
-            it!</p>
-          </div>
-        </div>
-        <div class="ds-l-sm-col--12 ds-l-md-col--12 ds-l-lg-col--3 benefit-prop">
+        <div class="ds-l-sm-col--12 ds-l-md-col--12 ds-l-lg-col--4 benefit-prop">
           <img src="/assets/img/homepage/ValueProp_4.svg" alt="Decrease Time">
           <div class="benefit-prop__body ds-u-padding-y--1">
             <div class="ds-u-font-size--lead ds-u-font-weight--semibold">Enable ACOs</div>
             <p>BCDA enables ACOs to make claims data requests more often - once a week.</p>
           </div>
         </div>
-        <div class="ds-l-sm-col--12 ds-l-md-col--12 ds-l-lg-col--3 benefit-prop">
+        <div class="ds-l-sm-col--12 ds-l-md-col--12 ds-l-lg-col--4 benefit-prop">
           <img src="/assets/img/homepage/ValueProp_3.svg" alt="Accessibility">
           <div class="benefit-prop__body ds-u-padding-y--1">
             <div class="ds-u-font-size--lead ds-u-font-weight--semibold">Standardize Claims Format</div>


### PR DESCRIPTION
### Change Details

Removed the "Reduce Burden" section from the "How can ACOs benefit from BCDA" section.

It now shows the other three items.

![Screen Shot 2020-12-14 at 9 49 15 AM](https://user-images.githubusercontent.com/21049223/102109906-cc5d2080-3df1-11eb-9070-00022f27f46d.png)

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [ ] no PHI/PII is affected by this change

### Acceptance Validation

Remove Burden removed from static site.

### Feedback Requested

Please verify that this is the only content that needs to be updated.