### PR TITLE
BLSTANALYT-1933 - Fixing issues around reporting google analytics events

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -26,21 +26,4 @@
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.google-analytics.com/analytics.js"></script>
     <script async src="/assets/js/autotrack.js"></script>
-    <!-- <script>
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', 'UA-133491498-1', 'auto');
-
-        // Implementing the following trackers via auto track
-        // https://github.com/googleanalytics/autotrack
-        ga('require', 'eventTracker');
-        ga('require', 'impressionTracker');
-        ga('require', 'mediaQueryTracker');
-        ga('require', 'maxScrollTracker');
-        ga('require', 'outboundLinkTracker');
-        ga('require', 'urlChangeTracker');
-        ga('require', 'pageVisibilityTracker');
-
-        // send the pageview
-        ga('send', 'pageview');
-    </script> -->
 </head>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -26,7 +26,7 @@
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.google-analytics.com/analytics.js"></script>
     <script async src="/assets/js/autotrack.js"></script>
-    <script>
+    <!-- <script>
         window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
         ga('create', 'UA-133491498-1', 'auto');
 
@@ -42,5 +42,5 @@
 
         // send the pageview
         ga('send', 'pageview');
-    </script>
+    </script> -->
 </head>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,7 +23,7 @@
       var anchors = document.querySelectorAll('a.ds-c-vertical-nav__label');
       for (const anchor of anchors) {
         anchor.addEventListener('click', function (event) {
-          utag.link({ ga_event_category: 'BCDA', ga_event_action: 'click: side-nav', ga_event_label: anchor.textContent })
+          utag.link({ ga_event_category: 'BCDA', ga_event_action: 'click: side-nav', ga_event_label: anchor.textContent.trim().toLowerCase() })
         })
       }
     }

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,54 +1,64 @@
 <!DOCTYPE html>
 <html lang="{{ page.lang | default: site.lang | default: 'en' }}">
 
-  {% include head.html %}
+{% include head.html %}
 
-  <body class="">
-    <script type="text/javascript">
-      var utag_data = {
-        language: "en",
-        environment: "{{ jekyll.environment }}",
-        site_name: "bcda"
+<body class="">
+  <script type="text/javascript">
+    var utag_data = {
+      language: "en",
+      environment: "{{ jekyll.environment }}",
+      site_name: "bcda"
+    }
+  </script>
+  <!-- Loading script asynchronously -->
+  <script type="text/javascript">
+      (function (a, b, c, d) {
+        a = 'https://tags.tiqcdn.com/utag/cmsgov/cms-general/{{ jekyll.environment }}/utag.js'; b = document; c = 'script'; d = b.createElement(c); d.src = a; d.type = 'text/java' + c; d.async = true; a = b.getElementsByTagName(c)[0]; a.parentNode.insertBefore(d, a);
+      })();
+  </script>
+  <!-- Adding event for all side nav clicks-->
+  <script type="text/javascript">
+    window.onload = function () {
+      var anchors = document.querySelectorAll('a.ds-c-vertical-nav__label');
+      for (var i = 0; i < anchors.length; i++) {
+        var anchor = anchors[i];
+        anchor.onclick = function () {
+          utag.link({ ga_event_category: 'side-nav', ga_event_action: 'click', ga_event_label: anchor.textContent })
+        }
       }
-    </script>
-    <!-- Loading script asynchronously -->
-    <script type="text/javascript">
-        (function (a, b, c, d) {
-          a = 'https://tags.tiqcdn.com/utag/cmsgov/cms-general/{{ jekyll.environment }}/utag.js'; b = document; c = 'script'; d = b.createElement(c); d.src = a; d.type = 'text/java' + c; d.async = true; a = b.getElementsByTagName(c)[0]; a.parentNode.insertBefore(d, a);
-        })();
-    </script>
-    <a class="ds-c-skip-nav" href="#main-content">Skip to main content</a>
+    }
+  </script>
+  <a class="ds-c-skip-nav" href="#main-content">Skip to main content</a>
 
-    {% include header.html %}
+  {% include header.html %}
 
-    <div id="content">
-      {{ content }}
-    </div>
+  <div id="content">
+    {{ content }}
+  </div>
 
-    {% include footer.html %}
+  {% include footer.html %}
 
-    <script
-    src="https://code.jquery.com/jquery-3.2.1.slim.min.js"
-    integrity="sha256-k2WSCIexGzOj3Euiig+TlR8gA0EmPjuc79OEeY5L45g="
-    crossorigin="anonymous"></script>
+  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js"
+    integrity="sha256-k2WSCIexGzOj3Euiig+TlR8gA0EmPjuc79OEeY5L45g=" crossorigin="anonymous"></script>
 
-    <!-- Feather Icons -->
-    <script src="https://unpkg.com/feather-icons"></script>
+  <!-- Feather Icons -->
+  <script src="https://unpkg.com/feather-icons"></script>
 
-    <script>
-      feather.replace()
-    </script>
+  <script>
+    feather.replace()
+  </script>
 
-    <!-- Custom JavaScript -->
-    <script src="{{ '/assets/js/main.js' | relative_url }}"></script>
-    <script src="{{ '/assets/js/accordion.js' | relative_url }}"></script>
-    <script src="{{ '/assets/js/code.js' | relative_url }}"></script>
-    <script src="{{ 'assets/js/mobile-nav-trigger-button.js' | relative_url }}"></script>
+  <!-- Custom JavaScript -->
+  <script src="{{ '/assets/js/main.js' | relative_url }}"></script>
+  <script src="{{ '/assets/js/accordion.js' | relative_url }}"></script>
+  <script src="{{ '/assets/js/code.js' | relative_url }}"></script>
+  <script src="{{ 'assets/js/mobile-nav-trigger-button.js' | relative_url }}"></script>
 
-    <!-- Crazy Egg Script
+  <!-- Crazy Egg Script
     BCDA will use this one day.  Just not now
     <script type="text/javascript" src="//script.crazyegg.com/pages/scripts/0078/9905.js" async="async"></script>
     -->
-  </body>
+</body>
 
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,12 +26,7 @@
           utag.link({ ga_event_category: 'BCDA', ga_event_action: 'click: side-nav', ga_event_label: anchor.textContent.trim().toLowerCase() })
         })
       }
-  </script>
-  <!-- Loading script asynchronously -->
-  <script type="text/javascript">
-      (function (a, b, c, d) {
-        a = 'https://tags.tiqcdn.com/utag/cmsgov/cms-general/{{ jekyll.environment }}/utag.js'; b = document; c = 'script'; d = b.createElement(c); d.src = a; d.type = 'text/java' + c; d.async = true; a = b.getElementsByTagName(c)[0]; a.parentNode.insertBefore(d, a);
-      })();
+    }
   </script>
   <a class="ds-c-skip-nav" href="#main">Skip to main content</a>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,7 +23,7 @@
       var anchors = document.querySelectorAll('a.ds-c-vertical-nav__label');
       for (const anchor of anchors) {
         anchor.addEventListener('click', function (event) {
-          utag.link({ ga_event_category: 'side-nav', ga_event_action: 'click', ga_event_label: anchor.textContent })
+          utag.link({ ga_event_category: 'BCDA', ga_event_action: 'click: side-nav', ga_event_label: anchor.textContent })
         })
       }
     }

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,11 +21,10 @@
   <script type="text/javascript">
     window.onload = function () {
       var anchors = document.querySelectorAll('a.ds-c-vertical-nav__label');
-      for (var i = 0; i < anchors.length; i++) {
-        var anchor = anchors[i];
-        anchor.onclick = function () {
+      for (const anchor of anchors) {
+        anchor.addEventListener('click', function (event) {
           utag.link({ ga_event_category: 'side-nav', ga_event_action: 'click', ga_event_label: anchor.textContent })
-        }
+        })
       }
     }
   </script>


### PR DESCRIPTION
## [BLSTANALYT-1933](https://jira.cms.gov/browse/BLSTANALYT-1933)
### Change Details
1. Remove Google Analytics script from the HEAD section. This conflicted (and caused issues) with the correct setting in the BODY section.
2. Adding script to add utag.link events when user clicks any of the side nav elements.

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [ ] no PHI/PII is affected by this change

### Acceptance Validation
1. Validated with the BLAST team that removing the GA script from the HEAD section fixed the issue of reporting events.
2. Using Omnibug extension, validated that we have a GA event when clicking on the side nav elements.

![Screen Shot 2020-12-15 at 3 30 05 PM](https://user-images.githubusercontent.com/21049223/102280496-7a4bf600-3eea-11eb-9f1b-18a04097bf66.png)
