### PR TITLE
Fix contrast issue with the homepage's update section

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,7 +129,7 @@ id: home
   </section>
 
   <!-- Updates -->
-  <div class="ds-u-fill--primary-darker">
+  <div class="ds-u-fill--primary-darker ds-base--inverse">
     <section class="ds-l-container ds-u-padding--1 ds-u-sm-padding--2 ds-u-md-padding--3 ds-u-lg-padding--4 ds-u-xl-padding--5 ds-u-color--white">
       <h1 class="ds-u-color--white">The Latest & Greatest from BCDA!</h1>
       <div class="ds-u-padding-y--2">


### PR DESCRIPTION
We had contrast issues with links found within our Updates section. See:

<img width="1282" alt="link contrast updates" src="https://user-images.githubusercontent.com/21049223/102517579-72f12d80-404d-11eb-8a1d-e9c147341346.png">

### Change Details

Apply [CMS Design inverse text color scheme](https://design.cms.gov/styles/base/). We are also using this scheme in our FAQ section (which also has a dark background).

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation

Added some dummy links to verify the contrast is working as expected.

![Screen Shot 2020-12-17 at 9 47 38 AM](https://user-images.githubusercontent.com/21049223/102517771-af248e00-404d-11eb-9f26-5e556d09732d.png)
