### PR TITLE
Final updates to static site

### DIFF
--- a/_includes/build/access_token.html
+++ b/_includes/build/access_token.html
@@ -13,7 +13,7 @@ F9780d323588f1cdfc3e63e95a8cbdcdd47602ff48a537b51dc5d7834bf466416a716bd4508e904a
     <div class="ds-c-alert__body">
       <h3 class="ds-c-alert__heading">These credentials do not work in production.</h3>
       <p class="ds-c-alert__text">
-	Note: These credentials will not work in the production environment. Please follow along using the credentials you were issued.
+	The sample credentials above will not work in the production environment. For production data, follow along using the credentials your ACO was issued.
 	</div>
   </div>
 

--- a/_includes/build/authorization.html
+++ b/_includes/build/authorization.html
@@ -1,3 +1,3 @@
 <p>
-	To complete any other operations with the API, you will need to be authorized. All SSP ACO’s are currently eligible for authorization through the ACO-MS system.
+	To complete any other operations with the API, you will need to be authorized. All SSP ACOs are currently eligible for authorization through the ACO-MS system.
 </p>

--- a/_includes/build/bcda_credentials.html
+++ b/_includes/build/bcda_credentials.html
@@ -6,12 +6,12 @@
     <div class="ds-c-alert__body">
       <h3 class="ds-c-alert__heading">Your credentials are protected data.</h3>
       <p class="ds-c-alert__text">
-	Note: Please treat your credentials like protected data: store them safely and securely.    
+	Please treat your credentials like protected data: store them safely and securely.    
 	</div>
   </div>
 
 <h3>
-	SSP-ACO’s Gain Access through ACO-MS
+	SSP-ACOs Gain Access to BCDA through ACO-MS
 </h3>
 
 <p>

--- a/_includes/build/requesting_data_EOY.html
+++ b/_includes/build/requesting_data_EOY.html
@@ -62,7 +62,7 @@ Prefer: respond-async
 		Your access token is required and set as a header. Accept and Prefer headers are also required. The dollar sign ('$') before the word "export" in the URL indicates that the endpoint is an action rather than a resource. The format is defined by the FHIR Bulk Data Export spec.
 	</p>	
 	<p>
-		If the request was successful, a 202 Accepted response code will be returned and the response will include a Content-Location header. The value of the Content-Location header indicates the location to check for job status and outcome. In the example header below, the number 42 in the URL represents the ID of the export job. The claims returned in the job will be filtered to have a serviceDate of 12/31/30 or before.
+		If the request was successful, a 202 Accepted response code will be returned and the response will include a Content-Location header. The value of the Content-Location header indicates the location to check for job status and outcome. In the example header below, the number 42 in the URL represents the ID of the export job. The claims returned in the job will be filtered to have a serviceDate of 12/31/2020 or before.
 	</p>
 	<p>
 		If you try to request data from the /Patient endpoint or from the /Group endpoint without using the 'runout' identifier, you will receive a `400 Bad Request` error. The operational outcome will direct you to make a new request to the /Group endpoint with `runout`. 

--- a/_includes/build/requesting_data_EOY.html
+++ b/_includes/build/requesting_data_EOY.html
@@ -164,8 +164,8 @@ Accept-Encoding: gzip</code></pre>
 	</div>
 	
 	<p>
-		The "Accept-Encoding: gzip" header is optional, but will return a significantly smaller (40X smaller) file with a faster download speed. You	 will need to uncompress the file after downloading if you supply this header. When downloading multiple files, you can further speed up the process by downloading multiple files concurrently. The claims returned in the job will be filtered to have a serviceDate of 12/31/30 or before.	
+		The "Accept-Encoding: gzip" header is optional, but will return a significantly smaller (40X smaller) file with a faster download speed. You will need to uncompress the file after downloading if you supply this header. When downloading multiple files, you can further speed up the process by downloading multiple files concurrently. The claims returned in the job will be filtered to have a serviceDate of 12/31/2020 or before.	
 	</p>	
 	<p>	
-		The response will be the requested data as FHIR resources in NDJSON format. Each file related to a different resource type will appear separately and labeled as to which resource type it 	contains. Examples of data from each Resource Type are available in the guide to working with BCDA data.
+		The response will be the requested data as FHIR resources in NDJSON format. Each file related to a different resource type will appear separately and labeled as to which resource type it contains. Examples of data from each Resource Type are available in the <a href=/data/>guide to working with BCDA data</a>.
 	</p>

--- a/_includes/build/requesting_data_EOY.html
+++ b/_includes/build/requesting_data_EOY.html
@@ -1,6 +1,6 @@
 <h3>Step 1: Obtain an Access Token</h3>
 	<p>
-		See <a href="https://bcda.cms.gov/production/technical-user-guide/#authentication-and-authorization">Authentication and Authorization</a> above.
+		See <a href="#authorization">Authentication and Authorization</a> above.
 	</p>
 <h3>Step 2: Start a job to acquire data</h3>
 
@@ -141,8 +141,8 @@ Accept-Encoding: gzip</code></pre>
 	<p>
 	<ol>
 	    <li><b><a href="https://bcda.cms.gov/assets/data/ExplanationOfBenefit.ndjson" target="_blank"> Explanation of Benefit</a></b></li>
-	    <li><b><a href="https://bcda.cms.gov/assets/data/Coverage.ndjson" target="_blank"> Patient</a></b></li>
-	    <li><b><a href="https://bcda.cms.gov/assets/data/Patient.ndjson" target="_blank"> Coverage</a></b></li>
+	    <li><b><a href="https://bcda.cms.gov/assets/data/Patient.ndjson" target="_blank"> Patient</a></b></li>
+	    <li><b><a href="https://bcda.cms.gov/assets/data/Coverage.ndjson" target="_blank"> Coverage</a></b></li>
 	  </ol>
 	</p>
 

--- a/_includes/build/requesting_data_EOY.html
+++ b/_includes/build/requesting_data_EOY.html
@@ -158,7 +158,7 @@ Accept-Encoding: gzip</code></pre>
     	<div class="ds-c-alert__body">
     	  <h3 class="ds-c-alert__heading"> Files expire after 24 hours.</h3>
     	    <p class="ds-c-alert__text">
-				Note: You will need to download the data file within 24 hours of starting the request to a specific endpoint. Otherwise, the files will expire and you will need to restart the job.
+				You will need to download the data file within 24 hours of starting the request to a specific endpoint. Otherwise, the files will expire and you will need to restart the job.
 			</p>	
     	</div>
 	</div>

--- a/_includes/build/requesting_data_all_three.html
+++ b/_includes/build/requesting_data_all_three.html
@@ -2,14 +2,14 @@
     	<div class="ds-c-alert__body">
     	  <h3 class="ds-c-alert__heading"> The examples below are for the /Patient endpoint.</h3>
     	    <p class="ds-c-alert__text">
-    	      Note: We have provided a few examples below. But, we are retrieving resource types only from the /Patient endpoint for only certain resource types. The request and cURL statements can be altered to retrieve any combination of resource types and resource types from the /Group endpoint as needed.
+    	      We have provided a few examples below in which we show retrieving only certain resource types from the /Patient endpoint. The request and cURL statements can be altered to retrieve any combination of resource types and resource types from the /Group endpoint as needed.
     	  	</p>
     </div>
 </div>
 
 <h3>Step 1: Obtain an Access Token</h3>
 	<p>
-		See <a href="https://bcda.cms.gov/production/technical-user-guide/#authentication-and-authorization">Authentication and Authorization</a> above.
+		See <a href="#authorization">Authentication and Authorization</a> above.
 	</p>
 <h3>Step 2: Start a job to acquire data</h3>
 
@@ -147,8 +147,8 @@ Accept-Encoding: gzip</code></pre>
 	<p>
 	<ol>
 	    <li><b><a href="https://bcda.cms.gov/assets/data/ExplanationOfBenefit.ndjson" target="_blank"> Explanation of Benefit</a></b></li>
-	    <li><b><a href="https://bcda.cms.gov/assets/data/Coverage.ndjson" target="_blank"> Patient</a></b></li>
-	    <li><b><a href="https://bcda.cms.gov/assets/data/Patient.ndjson" target="_blank"> Coverage</a></b></li>
+	    <li><b><a href="https://bcda.cms.gov/assets/data/Patient.ndjson" target="_blank"> Patient</a></b></li>
+	    <li><b><a href="https://bcda.cms.gov/assets/data/Coverage.ndjson" target="_blank"> Coverage</a></b></li>
 	  </ol>
 	</p>
 
@@ -164,7 +164,7 @@ Accept-Encoding: gzip</code></pre>
     	<div class="ds-c-alert__body">
     	  <h3 class="ds-c-alert__heading"> Files expire after 24 hours.</h3>
     	    <p class="ds-c-alert__text">
-				Note: You will need to download the data file within 24 hours of starting the request to a specific endpoint. Otherwise, the files will expire and you will need to restart the job.
+				You will need to download the data file within 24 hours of starting the request to a specific endpoint. Otherwise, the files will expire and you will need to restart the job.
 			</p>	
     	</div>
 	</div>

--- a/_includes/build/requesting_filtered_data.html
+++ b/_includes/build/requesting_filtered_data.html
@@ -10,7 +10,7 @@
     	</h2>
     	    <p class="ds-c-alert__text">
     	      <p>
-    	      	Note: Before using _since for the first time, we recommend that you run an unfiltered request (without using _since) to all resource types on the /Patient or /Group endpoints in order to retrieve all historical data for your ACO's associated beneficiaries. You only need to do this once.
+    	      	Before using _since for the first time, we recommend that you run an unfiltered request (without using _since) to all resource types on the /Patient or /Group endpoints in order to retrieve all historical data for your ACO's associated beneficiaries. You only need to do this once.
     	      </p>
     	      <p>
     	      On subsequent calls you can begin retrieving incremental claims data for your beneficiaries using _since. We suggest using the transactionTime from your last bulk data request as the _since date.

--- a/_includes/build/requesting_filtered_data_since_Group.html
+++ b/_includes/build/requesting_filtered_data_since_Group.html
@@ -47,7 +47,7 @@ Prefer: respond-async
     	<div class="ds-c-alert__body">
     	  <h3 class="ds-c-alert__heading"> Attribution data is only updated once per month.</h3>
     	    <p class="ds-c-alert__text">
-    	      Note: While most claims data is updated on a weekly cadence (and we encourage you to retrieve your ACO's claims data weekly), ACO attribution is only updated one time per month, so you will only be able to retrieve historical claims data for newly attributed beneficiaries once per month. Additional calls will only yield duplicative data for these newly attributed beneficiaries.
+    	     While most claims data is updated on a weekly cadence (and we encourage you to retrieve your ACO's claims data weekly), ACO attribution is only updated one time per month, so you will only be able to retrieve historical claims data for newly attributed beneficiaries once per month. Additional calls will only yield duplicative data for these newly attributed beneficiaries.
     	  	</p>
     	</div>
 	</div>

--- a/_includes/data/cclf_v_bcda.html
+++ b/_includes/data/cclf_v_bcda.html
@@ -1,6 +1,6 @@
 <div>
   <p>The goal of the Beneficiary Claims Data API (BCDA) is to provide Accountable Care Organizations with the same claims data as they receive via Claim and Claim Line Feed files (CCLFs). The data delivered to you via BCDA should be the same information as the CCLFs, however this data is now delivered in a new format.</p>
-  <p>BCDA follows the bulk FHIR specification, and provides the same data as the CCLFs using three FHIR resources: Explanation Of Benefit (EOB), Patient, and Coverage. This means that your claims data will be delivered through three resource types rather than 12 CCLF files.</p>
+  <p>BCDA follows the bulk FHIR specification, and provides the same data as the CCLFs using three FHIR resources: Explanation of Benefit (EOB), Patient, and Coverage. This means that your claims data will be delivered through three resource types rather than 12 CCLF files.</p>
   <ul>
     <li> The <b>Explanation of Benefit</b> resource type provides the same information you’ve previously received in CCLF files 1-7. The EOB files contain the lines within an episode of care, including where and when the service was performed, the diagnosis codes, the provider who performed the service, and the cost of care.</li>
     <li>The <b>Patient</b> resource type can be thought of as your CCLF files 8 and 9: this is where you get your information about who your beneficiaries are, their demographic information, and updates to their patient identifiers.</li>

--- a/_includes/data/cclf_v_bcda.html
+++ b/_includes/data/cclf_v_bcda.html
@@ -1,5 +1,5 @@
 <div>
-  <p>The goal of the Beneficiary Claims Data API (BCDA) is to provide Accountable Care Organizations with the same claims data as they were receiving in Claim and Claim-line Feeds (CCLFs). The data delivered to you via BCDA should be the same information as the CCLFs, however this data is now delivered in a new format.</p>
+  <p>The goal of the Beneficiary Claims Data API (BCDA) is to provide Accountable Care Organizations with the same claims data as they receive via Claim and Claim Line Feed files (CCLFs). The data delivered to you via BCDA should be the same information as the CCLFs, however this data is now delivered in a new format.</p>
   <p>BCDA follows the bulk FHIR specification, and provides the same data as the CCLFs using three FHIR resources: Explanation Of Benefit (EOB), Patient, and Coverage. This means that your claims data will be delivered through three resource types rather than 12 CCLF files.</p>
   <ul>
     <li> The <b>Explanation of Benefit</b> resource type provides the same information you’ve previously received in CCLF files 1-7. The EOB files contain the lines within an episode of care, including where and when the service was performed, the diagnosis codes, the provider who performed the service, and the cost of care.</li>

--- a/_includes/data/data_dictionary.html
+++ b/_includes/data/data_dictionary.html
@@ -3,7 +3,7 @@
     The <a href="https://bcda.cms.gov/assets/data/CCLF_BCDA_BB_Crosswalk.xlsx" target="blank">CCLF to BCDA Data Dictionary</a> is provided to BCDA users to facilitate their data mapping process.
   </p>
   <p>
-    <b> The Data Dictionary was last updated in December 2020. </b>
+    <b> The Data Dictionary was last updated in November 2020. </b>
   </p>
   <p>
     Because BCDA delivers data in the FHIR format, data field names will be different from previous data fields delivered through CCLFs. In this spreadsheet, BCDA has provided a crosswalk between all CCLF data fields and their new locations within BCDA Claims files. The Data Dictionary also provides supplementary context for each of the CCLF/BCDA data fields, including:

--- a/_includes/data/sample_files.html
+++ b/_includes/data/sample_files.html
@@ -1,6 +1,6 @@
 <p>In order to aid in users' understanding of BCDA file data and structure, we provide sample Explanation of Benefit, Patient, and Coverage files for download. These files contain synthetic data, but the structure of the files is similar to the actual files you will be pulling and downloading from BCDA.</p>
   <ol>
-    <li><b><a href="https://bcda.cms.gov/assets/data/ExplanationOfBenefit.ndjson" target="_blank"> Explanation of Benefit</a></b></li>
-    <li><b><a href="https://bcda.cms.gov/assets/data/Coverage.ndjson" target="_blank"> Patient</a></b></li>
-    <li><b><a href="https://bcda.cms.gov/assets/data/Patient.ndjson" target="_blank"> Coverage</a></b></li>
+    <li><b><a href="https://bcda.cms.gov/assets/data/ExplanationOfBenefit.ndjson" target="_blank">Explanation of Benefit</a></b></li>
+    <li><b><a href="https://bcda.cms.gov/assets/data/Patient.ndjson" target="_blank">Patient</a></b></li>
+    <li><b><a href="https://bcda.cms.gov/assets/data/Coverage.ndjson" target="_blank">Coverage</a></b></li>
   </ol>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -42,6 +42,7 @@
             Fear Act</a></li>
         <li><a target="_blank" href="https://www.medicare.gov/about-us/plain-writing/plain-writing.html">Plain
             Writing</a></li>
+        <li><a title="Privacy settings" data-privacy-policy="modal-trigger-footer" onclick="utag.gdpr.showConsentPreferences()">Privacy Settings</a></li>
         <li><a target="_blank" href="https://www.usa.gov/">USA.gov</a></li>
       </ul>
     </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,4 @@
-<div class="ds-l-container">
+<div class="ds-l-container ds-u-padding--7">
   <div class="ds-l-row">
     <div class="ds-u-font-size--small ds-l-col--12 ds-l-sm-col--12 ds-l-lg-col--3 ds-u-margin-bottom--2">
       <div class="ds-u-float--left ds-u-margin-right--2">

--- a/_includes/guide/bcda_environments.html
+++ b/_includes/guide/bcda_environments.html
@@ -1,3 +1,3 @@
 <p>
-	The BCDA consists of two environments: sandbox and production. The environments feature the same endpoints, resources, and parameters. They differ only in who has access.
+	BCDA consists of two environments: sandbox and production. The environments feature the same endpoints, resources, and parameters. They differ only in who has access and whether synthetic or real beneficiary data is returned.
 </p>

--- a/_includes/guide/bcda_parameters.html
+++ b/_includes/guide/bcda_parameters.html
@@ -1,3 +1,3 @@
 <p>
-	Parameters are options that can be passed to the endpoint to influence the response. Parameters can be used to filter or select for certain desired data. We would like to highlight two query parameters used in the BCDA.
+	Parameters are options that can be passed to the endpoint to influence the response. Parameters can be used to filter or select for certain desired data. We would like to highlight two query parameters used in BCDA.
 </p>

--- a/_includes/guide/bcda_resource_types.html
+++ b/_includes/guide/bcda_resource_types.html
@@ -1,3 +1,3 @@
 <p>
-  The BCDA API utilizes three resource types under the <a href="https://www.hl7.org/fhir/" target="_blank">FHIR specification</a>.
+  BCDA uses three resource types under the <a href="https://www.hl7.org/fhir/" target="_blank">FHIR specification</a>.
 </p>

--- a/_includes/guide/group_endpoint.html
+++ b/_includes/guide/group_endpoint.html
@@ -5,7 +5,7 @@
 		Throughout January 2021, users will need to use the `runout` identifier with the /Group endpoint <b>in order to request any claims from BCDA's production environment</b>. Requests to the /Group and /Patient endpoints without the `runout` identifier will result in an error message. When using the `runout` identifier, data returned by the API will be restricted to claims with a service date of 12/31/2020 or earlier. 
 	</p>
 	<p>
-		These changes are in place to ensure that BCDA does not return any data not assigned to your organization during the transition between performance years. Please see the full details in the <a href="#requesting-data-EOY">End of Year Requests</a> section on the Building Your API page.
+		These changes are in place to ensure that BCDA does not return any data not assigned to your organization during the transition between performance years. Please see the full details in the <a href="/build/#requesting-data-EOY">End of Year Requests</a> section on the Building Your API page.
 	</p>
    </div>
 </div>

--- a/_includes/guide/production_environment.html
+++ b/_includes/guide/production_environment.html
@@ -1,6 +1,6 @@
 <p>
-	In order to obtain your organization’s claims data in the production environment, you must have obtained API credentials from either the ACO-MS system (for Shared Savings Program ACOs) or directly from the BCDA team (for non-SSP ACOs. Every request demands a bearer token which can only be obtained with active BCDA credentials.
+	In order to obtain your organization’s claims data in the production environment, you must have obtained API credentials from either the ACO-MS system (for Shared Savings Program ACOs) or directly from the BCDA team (for non-SSP ACOs). Every request demands a bearer token which can only be obtained with active BCDA credentials.
 </p>
 <p>
-	Representatives of SSP ACOs are now able to generate BCDA credentials in their ACO-MS portal accounts. To view instructions on how to generate API credentials, log into your ACO-MS account and navigate to the ACO-MS Knowledge Library. Before you generate BCDA credentials, please try out the BCDA Sandbox experience.
+	Representatives of SSP ACOs are now able to generate BCDA credentials in their ACO-MS portal accounts. To view instructions on how to generate API credentials, log into your ACO-MS account and navigate to the ACO-MS Knowledge Library. Before you generate BCDA credentials, please <a href="#try-the-api">try out the BCDA Sandbox experience</a>.
 </p>

--- a/_includes/guide/try_the_api.html
+++ b/_includes/guide/try_the_api.html
@@ -1,5 +1,5 @@
 <p>
-	To get you started with the BCDA API, we have provided the bare minimum steps to access data in the sandbox. Using the four cURL commands below, you should be able to walk through the standard process of retrieving data from the API:
+	To get you started with BCDA, we have provided the bare minimum steps to access data in the sandbox. Using the four cURL commands below, you should be able to walk through the standard process of retrieving data from the API:
 </p>
 <ol>
 	<li>Obtain an access token: How do I show the API that I can receive this data?</li>
@@ -163,8 +163,8 @@ Response Example after Downloading the Data
 <p>
 	<ol>
 		<li><b><a href="https://bcda.cms.gov/assets/data/ExplanationOfBenefit.ndjson" target="_blank"> Explanation of Benefit</a></b></li>
-		<li><b><a href="https://bcda.cms.gov/assets/data/Coverage.ndjson" target="_blank"> Patient</a></b></li>
-		<li><b><a href="https://bcda.cms.gov/assets/data/Patient.ndjson" target="_blank"> Coverage</a></b></li>
+		<li><b><a href="https://bcda.cms.gov/assets/data/Patient.ndjson" target="_blank"> Patient</a></b></li>
+		<li><b><a href="https://bcda.cms.gov/assets/data/Coverage.ndjson" target="_blank"> Coverage</a></b></li>
 	</ol>
 </p>
 
@@ -180,5 +180,5 @@ Response Example after Downloading the Data
 	If the all of the steps above worked, you will now have files of synthetic beneficiary claims data on your local machine! You have walked through the process of proving your authentication to the API, starting a job to compile your data, checking on that job using its ID number, and downloading the results using the filenames. This four step process is universal for BCDA data requests (and many other Bulk FHIR workflows).
 </p>
 <p>
-	Remember, this was just the most basic call for claims data that could be made to the BCDA. To see how to download different combinations of Resource Types, filter data by date, filter some beneficiary data by date while retrieving all data for others, and (most importantly) to download data for your organizations' real beneficiaries, see the Building Your Application page.
+	Remember, this was just the most basic call for claims data that could be made to BCDA. To see how to download different combinations of Resource Types, filter data by date, filter some beneficiary data by date while retrieving all data for others, and (most importantly) to download data for your organizations' real beneficiaries, see the <a href="/build.html">Building Your Application page</a>.
 </p>

--- a/_includes/updates/intro.html
+++ b/_includes/updates/intro.html
@@ -1,3 +1,3 @@
 <p>
-	Check back here to see major updates to the BCDA. For more history and updates on BCDA's journey, please view our public <a href="https://github.com/CMSgov/bcda-app" target="_blank"> GitHub repo</a>. You are also free to join the Google Group and look back on the questions and community troubleshooting there.
+	Check back here to see major updates to BCDA. For more history and updates on BCDA's journey, please view our public <a href="https://github.com/CMSgov/bcda-app" target="_blank">GitHub repo</a>. You are also welcome to join the <a href="https://groups.google.com/forum/#!forum/bc-api">BCDA Google Group</a> and look back on the questions and community troubleshooting there.
  </p>

--- a/_sass/components/_guide.scss
+++ b/_sass/components/_guide.scss
@@ -1,4 +1,4 @@
-#guide-content{
+.guide-content{
   pre {
     background-color: $color-gray-lightest;
     border-radius: 6px;

--- a/_updates/2020-10-28.html
+++ b/_updates/2020-10-28.html
@@ -2,12 +2,12 @@
 ---
 <div class="ds-u-padding-y--2">
   <div class="ds-u-font-size--h3 ds-u-font-weight--bold">
-    You've reached the bottom. See our GitHub repo for more history.
+    You've reached the bottom. See our <a href="https://github.com/CMSgov/bcda-app" target="_blank">GitHub repo</a> for more history.
   </div>
   <div class="ds-u-font-size--lead ds-u-padding-y--1">
     December 21 2020
   </div>
   <div>
-    For more history and updates on BCDA's journey, please view our public <a href="https://github.com/CMSgov/bcda-app" target="_blank"> GitHub repo</a>. You are also free to join the Google Group and look back on the questions and community troubleshooting there.
+    For more history and updates on BCDA's journey, please view our public <a href="https://github.com/CMSgov/bcda-app" target="_blank">GitHub repo</a>. You are also welcome to join the <a href="https://groups.google.com/forum/#!forum/bc-api">BCDA Google Group</a> and look back on the questions and community troubleshooting there.
   </div>
 </div>

--- a/_updates/2020-12-22.html
+++ b/_updates/2020-12-22.html
@@ -2,7 +2,7 @@
 ---
 <div class="ds-u-padding-y--2">
   <div class="ds-u-font-size--h3 ds-u-font-weight--bold">
-    BCDA Launches a redesigned site!
+    BCDA launches a redesigned site!
   </div>
   <div class="ds-u-font-size--lead ds-u-padding-y--1">
     December 22 2020
@@ -10,7 +10,7 @@
   <div>
     Welcome to BCDA's new website!
 
-    We have streamlined the documentation to better facilitate quick experimentation in sandbox, detailed onboarding in production, and to showcase and match our sibling API's. Please explore and do not be afraid to share your feedback with the team as we continue to iterate on these changes.
+    We have streamlined the documentation to better facilitate quick experimentation in sandbox, detailed onboarding in production, and to showcase and match our sibling APIs. Please explore and do not be afraid to share your feedback with the team as we continue to iterate on these changes.
 
     For returning visitors, all of the documentation and resources from the previous site are still here. 
   </div>

--- a/_updates/2020-12-29.html
+++ b/_updates/2020-12-29.html
@@ -21,7 +21,7 @@
       BCDA is introducing a new identifier in the /Group endpoint, called `runout`. Between December 2020 and mid-January 2021, this identifier will only return claims with a service date before December 31, 2020. <b>Until BCDA receives January 2021 attribution information, the only way to retrieve claims is to use the group ID `runout` with the /Group endpoint; requests to /Patient or /Group with other group IDs will fail.</b> After BCDA receives January 2021 attribution information, this same `runout` identifier will also be available for ACOs to receive claims runout information from 2020. 
    </p>
    <p>
-     Full details about how to implement these changes is available in the <a href="#requesting-data-EOY">End of Year Requests section on the Building Your API page</a>.
+     Full details about how to implement these changes is available in the <a href="/build.html#requesting-data-EOY">End of Year Requests section on the Building Your API page</a>.
    </p>
   </div>
 </div>

--- a/_updates/2020-12-29.html
+++ b/_updates/2020-12-29.html
@@ -21,7 +21,7 @@
       BCDA is introducing a new identifier in the /Group endpoint, called `runout`. Between December 2020 and mid-January 2021, this identifier will only return claims with a service date before December 31, 2020. <b>Until BCDA receives January 2021 attribution information, the only way to retrieve claims is to use the group ID `runout` with the /Group endpoint; requests to /Patient or /Group with other group IDs will fail.</b> After BCDA receives January 2021 attribution information, this same `runout` identifier will also be available for ACOs to receive claims runout information from 2020. 
    </p>
    <p>
-     Full details about how to implement these changes is available in the <a href="/build.html#requesting-data-EOY">End of Year Requests section on the Building Your API page</a>.
+     Full details about how to implement these changes are available in the <a href="/build.html#requesting-data-EOY">End of Year Requests section on the Building Your API page</a>.
    </p>
   </div>
 </div>

--- a/build.html
+++ b/build.html
@@ -96,7 +96,7 @@ layout: default
     <!-- Table of Contents END -->
 
     <main id="main" class="ds-l-md-col--8 ds-l-lg-col--9">
-      <div id="guide-content">
+      <div class="guide-content">
         <div id="bcda-user-guide">
           <h1>
             BCDA User Guide Documentation
@@ -142,7 +142,7 @@ layout: default
         <h1>
           Requesting Data during End of Year Attribution
         </h1>
-        <div class="ds-u-font-size--base">
+        <div class="ds-u-font-size--base guide-content">
           {% include build/requesting_data_EOY_intro.html %}
         </div>
       </div>
@@ -150,7 +150,7 @@ layout: default
         <h2>
           Request All Three Resource Types with /Group and `runout`
         </h2>
-        <div class="ds-u-font-size--base">
+        <div class="ds-u-font-size--base guide-content">
           {% include build/requesting_data_EOY.html %}
         </div>
       </div>
@@ -165,7 +165,7 @@ layout: default
           <h2>
             Request All Three Resource Types
           </h2>
-          <div class="ds-u-font-size--base">
+          <div class="ds-u-font-size--base guide-content">
             {% include build/requesting_data_all_three.html %}
           </div>
         </div>
@@ -182,7 +182,7 @@ layout: default
           <h2>
             Requesting using _since with the /Patient endpoint
           </h2>
-          <div class="ds-u-font-size--base">
+          <div class="ds-u-font-size--base guide-content">
             {% include build/requesting_filtered_data_since_Patient.html %}
           </div>
         </div>
@@ -190,7 +190,7 @@ layout: default
           <h2>
             Requesting using _since with the /Group endpoint
           </h2>
-          <div class="ds-u-font-size--base">
+          <div class="ds-u-font-size--base guide-content">
             {% include build/requesting_filtered_data_since_Group.html %}
           </div>
         </div>

--- a/guide.html
+++ b/guide.html
@@ -112,7 +112,7 @@ layout: default
       </ul>
     </aside>
     <main id="main" class="ds-l-md-col--8 ds-l-lg-col--9">
-      <div id="guide-content">
+      <div class="guide-content">
         <div id="what-is-an-api">
           <h1>
             What is an API?

--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@ id: home
             <div class="ds-u-padding-y--1">
               The Blue Button 2.0 API enables beneficiaries to connect their Medicare claims data to the applications, services, and research programs they trust.
             </div>
-            <div class="ds-l-container ds-u-padding-top--3 ds-u-justify-content--center">
+            <div class="ds-l-container ds-u-padding-top--5 ds-u-justify-content--center">
               <a class="ds-c-button ds-c-button--primary ds-u-justify-content--center ds-l-col--12" href="https://bluebutton.cms.gov/" target="_blank">BB 2.0</a>
             </div>
           </div>
@@ -179,7 +179,7 @@ id: home
             <div>
               The AB2D API provides stand-alone PDP sponsors with Medicare Parts A and B claims data for their active enrollees.
             </div>
-            <div class="ds-l-container ds-u-padding-top--5 ds-u-justify-content--center">
+            <div class="ds-l-container ds-u-padding-top--7 ds-u-justify-content--center">
               <a class="ds-c-button ds-c-button--primary ds-u-justify-content--center ds-l-col--12" href="https://ab2d.cms.gov/" target="_blank">AB2D</a>
             </div>
           </div>


### PR DESCRIPTION

Following our final round of language and formatting reviews, this PR represents the final updates to the glown-up static site.

### Proposed Changes

* Add padding between bottom of content and footer
* Even out the vertical location of homepage buttons
* Update relative links to ensure they go to the new site, not the old site
* Very small typo and grammar fixes



### Security Implications


- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

- [ X ] no PHI/PII is affected by this change



### Acceptance Validation

Please confirm using stage that:
* links go where they're supposed to go
* nothing that wasn't broken earlier is newly broken
* there are no remaining instances of "the BCDA" (should be "BCDA"), "Note:", or "12/31/30" as a serviceDate.

### Feedback Requested

Give yourself a big pat on the back and high-five a teammate remotely.
