### PR TITLE
Fixing remaining AXE errors

### DIFF
--- a/_includes/build/bcda_user_guide.html
+++ b/_includes/build/bcda_user_guide.html
@@ -4,7 +4,7 @@ For each request and operation, we provide example requests and example cURL com
 
 <div class="ds-c-alert ds-c-alert--hide-icon">
     <div class="ds-c-alert__body">
-      <h3 class="ds-c-alert__heading">Temporary Change to Production Requests</h3>
+      <h2 class="ds-c-alert__heading">Temporary Change to Production Requests</h2>
       <p class="ds-c-alert__text">
 	Throughout January 2021, users will need to use the `runout` identifier with the /Group endpoint <b>in order to request any claims from BCDA's production environment</b>. Requests to the /Group and /Patient endpoints without the `runout` identifier will result in an error message. When using the `runout` identifier, data returned by the API will be restricted to claims with a service date of 12/31/2020 or earlier.  
 </p>

--- a/_includes/build/requesting_data.html
+++ b/_includes/build/requesting_data.html
@@ -1,6 +1,6 @@
 <div class="ds-c-alert ds-c-alert--hide-icon">
     <div class="ds-c-alert__body">
-      <h3 class="ds-c-alert__heading">Temporary Change to Production Requests</h3>
+      <h2 class="ds-c-alert__heading">Temporary Change to Production Requests</h2>
       <p class="ds-c-alert__text">
 	Throughout January 2021, users will need to use the `runout` identifier with the /Group endpoint <b>in order to request any claims from BCDA's production environment</b>. Requests to the /Group and /Patient endpoints without the `runout` identifier will result in an error message. When using the `runout` identifier, data returned by the API will be restricted to claims with a service date of 12/31/2020 or earlier. 
 </p>

--- a/_includes/build/requesting_data_EOY.html
+++ b/_includes/build/requesting_data_EOY.html
@@ -76,7 +76,7 @@ Prefer: respond-async
 
 
 
-<h3 id="checkJob">Step 3: Check the job status</h3>
+<h3 id="checkJobEOY">Step 3: Check the job status</h3>
 
 <h4>Request to check the job status</h4>
 	<pre><code>GET https://api.bcda.cms.gov/api/v1/jobs/42</code></pre>
@@ -123,7 +123,7 @@ Accept: application/fhir+json</code></pre>
 	<p>The status will change from `202 Accepted` to `200 OK` when the export job is complete and the data is ready to be downloaded.</p>	
 	<p>Claims data can be found at the URLs within the output field. The claims returned in the job will be filtered to have a serviceDate of 12/31/2020 or before. The number 42 in the data file URLs is the same job ID from the Content-Location header URL in the previous step. If some of the data cannot be exported due to errors, details of the errors can be found at the URLs in the error field. The errors are provided in an NDJSON file as FHIR OperationOutcome resources.</p>
 
-<h3 id="downloadData">Step 4: Download the data</h3>
+<h3 id="downloadDataEOY">Step 4: Download the data</h3>
 
 <h4>Request to download the data</h4>
 	<pre><code>GET https://api.bcda.cms.gov/data/42/afd22dfa-c239-4063-8882-eb2712f9f638.ndjson</code></pre>

--- a/_includes/build/requesting_data_EOY_intro.html
+++ b/_includes/build/requesting_data_EOY_intro.html
@@ -1,6 +1,6 @@
 <div class="ds-c-alert ds-c-alert--hide-icon">
     <div class="ds-c-alert__body">
-      <h3 class="ds-c-alert__heading">Temporary Change to Production Requests</h3>
+      <h2 class="ds-c-alert__heading">Temporary Change to Production Requests</h2>
       <p class="ds-c-alert__text">
 	Throughout January 2021, users will need to use the `runout` identifier with the /Group endpoint <b>in order to request any claims from BCDA's production environment</b>. Requests to the /Group and /Patient endpoints without the `runout` identifier will result in an error message. When using the `runout` identifier, data returned by the API will be restricted to claims with a service date of 12/31/2020 or earlier. 
 </p>

--- a/_includes/guide/group_endpoint.html
+++ b/_includes/guide/group_endpoint.html
@@ -1,6 +1,6 @@
 <div class="ds-c-alert ds-c-alert--hide-icon">
     <div class="ds-c-alert__body">
-      <h3 class="ds-c-alert__heading">Temporary Change to Production Requests</h3>
+      <h2 class="ds-c-alert__heading">Temporary Change to Production Requests</h2>
       <p class="ds-c-alert__text">
 		Throughout January 2021, users will need to use the `runout` identifier with the /Group endpoint <b>in order to request any claims from BCDA's production environment</b>. Requests to the /Group and /Patient endpoints without the `runout` identifier will result in an error message. When using the `runout` identifier, data returned by the API will be restricted to claims with a service date of 12/31/2020 or earlier. 
 	</p>


### PR DESCRIPTION
Resolving remaining AXE issues before static-site-glowup release

### Change Details
1. Fixing duplicate IDs. We had duplicated the checkJob and downloadData IDs when we introduced the EOY section.
2. Fixed a couple of auth links that linked outside of the site (instead of referencing internal links)
3. Ensured that H tags are in descending order.

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation

1. Ran AXE tests locally and verified that all errors are resolved.

```
docker run --init --rm --cap-add=SYS_ADMIN orenfromberg/axe-puppeteer-ci:1.0.0@sha256:e7fd3be771e95588296c67dbc73deaa845fc01f385494d56269739d7eb906188  http://host.docker.internal:4000
  0 violations found!

docker run --init --rm --cap-add=SYS_ADMIN orenfromberg/axe-puppeteer-ci:1.0.0@sha256:e7fd3be771e95588296c67dbc73deaa845fc01f385494d56269739d7eb906188  http://host.docker.internal:4000/guide
  0 violations found!

docker run --init --rm --cap-add=SYS_ADMIN orenfromberg/axe-puppeteer-ci:1.0.0@sha256:e7fd3be771e95588296c67dbc73deaa845fc01f385494d56269739d7eb906188  http://host.docker.internal:4000/build.html
  0 violations found!

docker run --init --rm --cap-add=SYS_ADMIN orenfromberg/axe-puppeteer-ci:1.0.0@sha256:e7fd3be771e95588296c67dbc73deaa845fc01f385494d56269739d7eb906188  http://host.docker.internal:4000/data.html
  0 violations found!

docker run --init --rm --cap-add=SYS_ADMIN orenfromberg/axe-puppeteer-ci:1.0.0@sha256:e7fd3be771e95588296c67dbc73deaa845fc01f385494d56269739d7eb906188  http://host.docker.internal:4000/updates.html
  0 violations found!
```

2. Successfully ran our [508 Compliance Test](https://bcda-ci.adhocteam.us/job/BCDA%20-%20Static%20Site%20508%20Compliance/187/) on Jenkins.