### PR TITLE
Update to bundler version 2.2.2

### DIFF
--- a/Dockerfiles/Dockerfile.static_site
+++ b/Dockerfiles/Dockerfile.static_site
@@ -1,4 +1,4 @@
-FROM jekyll/builder
+FROM jekyll/builder:4.2.0
 
 ENV BUNDLE_PATH=$GEM_HOME
 WORKDIR /bcda-site-static

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-linux-musl
 
 DEPENDENCIES
   jekyll (= 4.0.0)
@@ -75,4 +76,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   2.1.4
+   2.2.2

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ A static Jekyll site for the BCDA splash page: [https://bcda.cms.gov](https://bc
 ## Requirements
 It is assumed that the environment already has these installed:
 * [rbenv](https://github.com/rbenv/rbenv) or [rvm](https://rvm.io/) to install versioned ruby
-* [ruby](https://www.ruby-lang.org/en/) currently using 2.4
-* [jekyll](https://jekyllrb.com/) currently using 3.5.2
-- [npm](https://www.npmjs.com/) currently using 12.14.1
+* [ruby](https://www.ruby-lang.org/en/) currently using 2.7.1
+* [jekyll](https://jekyllrb.com/) currently using 4.2.0
+- [npm](https://www.npmjs.com/) currently using 6.13.4
 * [Docker](https://docs.docker.com/install/) to standardize builds across all contributors' local machines
 * [Docker Compose](https://docs.docker.com/compose/install/) to define and run multi-container Docker applications
 


### PR DESCRIPTION
The development team for `jekyll/builder` pushed out an [update](https://hub.docker.com/r/jekyll/builder/tags?page=1&ordering=last_updated) before the holidays, resulting in some dependencies to be upgraded.  We should pull those dependency updates into our `Gemfile.lock`

### Change Details

- Update `Gemfile.lock` to reference `bundler v2.2.2`

### Security Implications


- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change


### Acceptance Validation

Completed a successful [build/deploy](https://bcda-ci.adhocteam.us/job/BCDA%20-%20Deploy%20-%20Static%20Site/111/parameters/) to stage from this feature branch.

### Feedback Requested

Please review.
