### PR TITLE
BCDA-4231 - Update credentials to newly refreshed ones

### DIFF
--- a/_includes/guide/credentials.html
+++ b/_includes/guide/credentials.html
@@ -2,14 +2,14 @@
 <div class="acc_content">
     Client ID:
     {%- capture client_id -%}
-    3841c594-a8c0-41e5-98cc-38bb45360d3c
+    0c527d2e-2e8a-4808-b11d-0fa06baf8254
     {%- endcapture -%}
 
     {% include copy_snippet.md code=client_id aco='Extra-Small ACO' type='Client ID' %}
 
     Client Secret:
     {%- capture client_secret -%}
-    f9780d323588f1cdfc3e63e95a8cbdcdd47602ff48a537b51dc5d7834bf466416a716bd4508e904a
+    36e0ea2217e6d6180f3ab1108d02ca100d684ebdccc04817ce842300996e568c3d77fc61d84006a3
     {%- endcapture -%}
 
     {% include copy_snippet.md code=client_secret aco='Extra-Small ACO' type='Client Secret' %}
@@ -19,14 +19,14 @@
 <div class="acc_content">
     Client ID:
     {%- capture client_id -%}
-    d5f83f74-6c55-4f1e-9d16-0022688171ba
+    f0d89614-efb9-49fa-bb38-996811f235a1
     {%- endcapture -%}
 
     {% include copy_snippet.md code=client_id aco='Small ACO' type='Client ID' %}
 
     Client Secret:
     {%- capture client_secret -%}
-    01c23cf3f31f82a5c2dcef5136a8eaa32959158351f4e28aaec5fc6550cb2a5b5d112c5b8aacc434
+    524a3e8985715d533ae4f182be3dd55778cc3b82179eb1b28759733fd5ddc787a535b548420af1a7
     {%- endcapture -%}
 
     {% include copy_snippet.md code=client_secret aco='Small ACO' type='Client Secret' %}
@@ -36,14 +36,14 @@
 <div class="acc_content">
     Client ID:
     {%- capture client_id -%}
-    8c75a6f6-02b9-4a47-96c1-0bd6efd4b5e3
+    635003cf-e337-4f91-be51-73b50e27ae9a
     {%- endcapture -%}
 
     {% include copy_snippet.md code=client_id aco='Medium ACO' type='Client ID' %}
 
     Client Secret:
     {%- capture client_secret -%}
-    e1c920141c4aca6b8f726fa8aa0f7b55e095fd1ea3368a5f24b3636fdc907f113d6677977c7259dd
+    5b1b45658dd9b75ef145a529c77d0c934e64788ba2ce9ce5195b834c1960a642aec689be485ad651
     {%- endcapture -%}
 
     {% include copy_snippet.md code=client_secret aco='Medium ACO' type='Client Secret' %}
@@ -53,14 +53,14 @@
 <div class="acc_content">
     Client ID:
     {%- capture client_id -%}
-    f268a8c6-8a29-4d2b-8b92-263dc775750d
+    8e85dd71-9206-44bb-a07e-638b29b316c1
     {%- endcapture -%}
 
     {% include copy_snippet.md code=client_id aco='Large ACO' type='Client ID' %}
 
     Client Secret:
     {%- capture client_secret -%}
-    78ed083ad8e49475f36d04153649012b92c363a538ac97beaf0f7900403989581fc35324baa31e36
+    5104f03d92ccadf598bf75f5754acc923337361504a401b050cd4cf4e2dcd799c00bec361bf264ed
     {%- endcapture -%}
 
     {% include copy_snippet.md code=client_secret aco='Large ACO' type='Client Secret' %}
@@ -70,14 +70,14 @@
 <div class="acc_content">
     Client ID:
     {%- capture client_id -%}
-    6152afb4-c555-46e4-93de-fa16a441d643
+    aa2d6b93-bbe7-4d1b-8cc5-9a5172fae3a6
     {%- endcapture -%}
 
     {% include copy_snippet.md code=client_id aco='Extra-Large ACO' type='Client ID' %}
 
     Client Secret:
     {%- capture client_secret -%}
-    1ace5a0e9fdf0c3d713e8c029269eacd024732ccd59e2cf283374e0f8dc93b34429d71b77e55b9a2
+    3f18d01dbbc97634a10c0631c6cffced4d7949ddb2a54b6f400792fd55c5538473dbfccfe715bd8f
     {%- endcapture -%}
 
     {% include copy_snippet.md code=client_secret aco='Extra-Large ACO' type='Client Secret' %}


### PR DESCRIPTION

### Part of [BCDA-4231](https://jira.cms.gov/browse/BCDA-4231)

Updating synthetic ACO credentials on sandbox to reflect newly generated client secrets.

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [x] new data stored or transmitted
Static site updated to reference new set of client secrets for our various test ACOs.
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change
Affect synthetic ACOs, so no real PHI/PII information involved.

### Acceptance Validation
1. Validate that all of the clientID:clientSecret tuples work as expected.

### Follow Up Work
1. Once this PR is merged and deployed to production, we need to remove the other set of credentials.