### PR TITLE
Sl/bcda 4553 update example creds

### DIFF
--- a/_includes/build/access_token.html
+++ b/_includes/build/access_token.html
@@ -3,10 +3,10 @@
 </p>
 
 <pre><code><b>Example Client ID (Extra-Small ACOs):</b>
-3841c594-a8c0-41e5-98cc-38bb45360d3c
+0c527d2e-2e8a-4808-b11d-0fa06baf8254
 
 <b>Example Client Secret (Extra-Small ACOs):</b>
-F9780d323588f1cdfc3e63e95a8cbdcdd47602ff48a537b51dc5d7834bf466416a716bd4508e904a
+36e0ea2217e6d6180f3ab1108d02ca100d684ebdccc04817ce842300996e568c3d77fc61d84006a3
 </code></pre>
 
 <div class="ds-c-alert ds-c-alert--hide-icon">

--- a/_includes/guide/try_the_api.html
+++ b/_includes/guide/try_the_api.html
@@ -36,7 +36,7 @@
 	Sample cURL Command to Submit Credentials for an Access Token
 </h3>
 <pre><code>curl -d '' -X POST 'https://sandbox.bcda.cms.gov/auth/token' \
---user 3841c594-a8c0-41e5-98cc-38bb45360d3c:f9780d323588f1cdfc3e63e95a8cbdcdd47602ff48a537b51dc5d7834bf466416a716bd4508e904a \
+--user 0c527d2e-2e8a-4808-b11d-0fa06baf8254:36e0ea2217e6d6180f3ab1108d02ca100d684ebdccc04817ce842300996e568c3d77fc61d84006a3 \
 -H "accept: application/json"</code></pre>
 
 <h3>


### PR DESCRIPTION
### Fixes [BCDA-4553](https://jira.cms.gov/browse/BCDA-4553)

Credentials used in examples are deactivated.

### Change Details

Replaced invalid credentials with activated creds in the examples.

### Security Implications

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

- [x] no PHI/PII is affected by this change

### Acceptance Validation

New activate creds are reflected on the static site.

### Feedback Requested

Pretty straight forward. Couldn't find any mention of them anywhere else.