### PR TITLE
bcda-4547 Feature: Update static site typos

### DIFF
--- a/_includes/guide/since_parameter.html
+++ b/_includes/guide/since_parameter.html
@@ -1,11 +1,7 @@
 <p>
-	The /Patient endpoint allows you to request ExplanationOfBenefit, Patient, and/or Coverage data for all beneficiaries assigned or assignable to your ACO. 
+	The _since parameter allows you to apply a date parameter to your bulk data requests. Instead of receiving the full record of historical data every time you request data from an endpoint, you will be able to use _since to submit a date. The API will then produce claims data from the bulk data endpoints that have been loaded since the entered date.
 </p>
 
 <p>
-	Note that the /Patient endpoint does not allow requests for data patient-by-patient. By the Bulk FHIR specification, only data for all patients associated with the authorized users’ credentials can be returned.
-</p>
-
-<p>
-	You may also filter data by date using the _since parameter. If no filter is applied, a request to the /Patient endpoint in BCDA returns seven years of historical data for all assigned and assignable beneficiaries.
+	To learn more about the differences using _since between the /Patient and /Group endpoints see the above section.
 </p>

--- a/_includes/guide/since_parameter.html
+++ b/_includes/guide/since_parameter.html
@@ -3,5 +3,5 @@
 </p>
 
 <p>
-	To learn more about the differences using _since between the /Patient and /Group endpoints see the above section.
+	To learn more about the differences using _since between the /Patient and /Group endpoints see the <a href="https://bcda.cms.gov/guide.html#fhir-endpoints" target="_blank" class="in-text__link">FHIR endpoints</a> section above.
 </p>

--- a/_includes/guide/type_parameter.html
+++ b/_includes/guide/type_parameter.html
@@ -3,5 +3,5 @@
 </p>
 
 <p>
-	To learn more about the Resource Types see the Resource types section.
+	To learn more about the Resource Types see the <a href="https://bcda.cms.gov/guide.html#fhir-types" target="_blank" class="in-text__link">FHIR Resource Types</a> section above.
 </p>

--- a/_includes/guide/type_parameter.html
+++ b/_includes/guide/type_parameter.html
@@ -1,11 +1,7 @@
 <p>
-	The /Patient endpoint allows you to request ExplanationOfBenefit, Patient, and/or Coverage data for all beneficiaries assigned or assignable to your ACO. 
+	The _type parameter allows you to request different Resource Types from the API. Instead of receiving data from all three Resource Types when no _type parameter is specified, you will be able to use the _type parameter to submit one or more Resource Types. The API will then produce data from the specified Resource Types.
 </p>
 
 <p>
-	Note that the /Patient endpoint does not allow requests for data patient-by-patient. By the Bulk FHIR specification, only data for all patients associated with the authorized users’ credentials can be returned.
-</p>
-
-<p>
-	You may also filter data by date using the _since parameter. If no filter is applied, a request to the /Patient endpoint in BCDA returns seven years of historical data for all assigned and assignable beneficiaries.
+	To learn more about the Resource Types see the Resource types section.
 </p>


### PR DESCRIPTION
### Fixes [BCDA-4547](https://jira.cms.gov/browse/BCDA-4547)

There have been some long running typos on the guide section of the site for descrying the `type` and `since` parameters.

### Change Details

- Update `since_parameter.html` with the appropriate description.
- Update `type_parameter.html` with the appropriate description.

### Security Implications

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

- [x] no PHI/PII is affected by this change

### Acceptance Validation

The `_type` and `_since` parameter sections on the guide give their proper descriptions.

### Feedback Requested

Let me know if I should add or edit any other wording.