### PR TITLE
Run Accessibility Scan in Github Actions CI

### DIFF
--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -18,7 +18,7 @@ test() {
     curl localhost:4000 | grep "Join the Google Group"
     
     # Perform accessibility scan
-    TARGETS_TEST_ENV=http://host.docker.internal:4000
+    TARGET_TEST_ENV=http://host.docker.internal:4000
     TARGETS_TO_SCAN="${TARGET_TEST_ENV}"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/guide.html"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/build.html"

--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -16,6 +16,14 @@ test() {
     docker-compose run -u "$(id -u "${USER}")":"$(id -g "${USER}")" --publish 4000:4000 --rm --entrypoint "bundle exec jekyll serve -H 0.0.0.0" -d static_site
     sleep 20
     curl localhost:4000 | grep "Join the Google Group"
+    
+    # Perform accessibility scan
+    TARGETS_TO_SCAN="http://host.docker/internal:4000"
+    TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/guide.html"
+    TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/build.html"
+    TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/data.html"
+    TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/updates.html"
+    docker run --add-host=host.docker.internal:host-gateway --init --rm --cap-add=SYS_ADMIN orenfromberg/axe-puppeteer-ci:1.0.0@sha256:f83527a3ae8ab74088c001abfe44836946ba73f0afbbf460447f8a0c40281e70 ${TARGETS_TO_SCAN}
 }
 
 main() {

--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -18,7 +18,7 @@ test() {
     curl localhost:4000 | grep "Join the Google Group"
     
     # Perform accessibility scan
-    TARGETS_TO_SCAN="http://host.docker.internal:4000"
+    TARGETS_TO_SCAN=http://host.docker.internal:4000
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/guide.html"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/build.html"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/data.html"

--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -18,7 +18,7 @@ test() {
     curl localhost:4000 | grep "Join the Google Group"
     
     # Perform accessibility scan
-    TARGETS_TO_SCAN="http://host.docker/internal:4000"
+    TARGETS_TO_SCAN="http://host.docker.internal:4000"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/guide.html"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/build.html"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/data.html"

--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -18,7 +18,8 @@ test() {
     curl localhost:4000 | grep "Join the Google Group"
     
     # Perform accessibility scan
-    TARGETS_TO_SCAN=http://host.docker.internal:4000
+    TARGETS_TEST_ENV=http://host.docker.internal:4000
+    TARGETS_TO_SCAN="${TARGET_TEST_ENV}"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/guide.html"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/build.html"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/data.html"


### PR DESCRIPTION
The static site is scanned for accessibility issues on a weekly basis; but there is a desire to shift left, run accessibility scans early/often, and block PRs when there is an accessibility regression.

### Change Details

- Added accessibility scanning within GitHub Actions.

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation

Successful execution in Github Actions within this feature branch.

### Feedback Requested

Please review.
