### PR TITLE
Remove deprecated Quickstart file

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
 destination: ./_site
-title: DEMO - Beneficiary Claims Data API
+title: Beneficiary Claims Data API
 email: bc-api@googlegroups.com
 description: >- # this means to ignore newlines until "baseurl:"
   Shared Savings Program ACOs can use this FHIR-based API to retrieve bulk Medicare claims data related to their assignable or prospectively assigned beneficiaries. Under construction; feedback invited.

--- a/quickstart.html
+++ b/quickstart.html
@@ -1,6 +1,0 @@
----
-id: quickstart
-title: Quickstart
-layout: default
----
-<h1>Quickstart</h1>


### PR DESCRIPTION
The `quickstart.html` file is deprecated, and no longer used within the Static Site.  However, it is still being built and renders an incomplete page if directly accessed.

### Change Details

- Removed `quickstart.html`
- Removed "DEMO" verbiage in config file

### Security Implications


- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation

We are now seeing `404` when accessing `quickstart.html`.

### Feedback Requested

Please review.
