### PR TITLE
BCDA-7198: Fix curl instructions for retrieving sandbox tokens

### DIFF
--- a/_includes/build/access_token.html
+++ b/_includes/build/access_token.html
@@ -35,7 +35,7 @@
 	<p>
 		cURL Option 1: This cURL command requires separate base-64 encryption. We have concatenated the base64 encoding of the ‘Client ID : Secret’ as the argument to the -H flag. Please note that the URL in the Production environment will be different. 
 	</p>
-<pre><code>curl -d '' -X POST 'https://sandbox.bcda.cms.gov/auth/token ' \
+<pre><code>curl -d '' -X POST 'https://sandbox.bcda.cms.gov/auth/token' \
 	-H "accept: application/json" \
 	-H "authorization: Basic MjQ2MmM5NmItNjQyNy00ZWZiLWFlZDctMTE4ZTIwYzJlOTk3OjhlODdmMGViYzUwZDEwZjFiYzk3MzQzMjlhOTkwMDE3OWI4NGNjZDM5ZTRkMDkyMGI5MDVjYzM1OWNmNmU5NGE2ZTc2MGJiZTNhMDg5MGM3"</code></pre>
 

--- a/_includes/build/access_token.html
+++ b/_includes/build/access_token.html
@@ -35,8 +35,8 @@
 	<p>
 		cURL Option 1: This cURL command requires separate base-64 encryption. We have concatenated the base64 encoding of the ‘Client ID : Secret’ as the argument to the -H flag. Please note that the URL in the Production environment will be different. 
 	</p>
-<pre><code>curl -d '' -X POST 'https://sandbox.bcda.cms.gov/auth/token ' \ 
-	-H "accept: application/json" \ 
+<pre><code>curl -d '' -X POST 'https://sandbox.bcda.cms.gov/auth/token ' \
+	-H "accept: application/json" \
 	-H "authorization: Basic MjQ2MmM5NmItNjQyNy00ZWZiLWFlZDctMTE4ZTIwYzJlOTk3OjhlODdmMGViYzUwZDEwZjFiYzk3MzQzMjlhOTkwMDE3OWI4NGNjZDM5ZTRkMDkyMGI5MDVjYzM1OWNmNmU5NGE2ZTc2MGJiZTNhMDg5MGM3"</code></pre>
 
 <p>

--- a/_includes/build/access_token.html
+++ b/_includes/build/access_token.html
@@ -35,9 +35,9 @@
 	<p>
 		cURL Option 1: This cURL command requires separate base-64 encryption. We have concatenated the base64 encoding of the ‘Client ID : Secret’ as the argument to the -H flag. Please note that the URL in the Production environment will be different. 
 	</p>
-<pre><code>curl -d '' -X POST 'https://sandbox.bcda.cms.gov/ ' \ 
+<pre><code>curl -d '' -X POST 'https://sandbox.bcda.cms.gov/auth/token ' \ 
 	-H "accept: application/json" \ 
-	-H "authorization: Basic Mzg0MWM1OTQtYThjMC00MWU1Tk4Y2MtMzhiYjQ1MzYwZDNjOmY5NzgwZDMyMzU4OGYxY2RmYzNlNjNlOTVhOGNiZGNkZDQ3NjAyZmY0OGE1MzdiNTFkYzVkNzgzNGJmNDY2NDE2YTcxNmJkNDUwOGU5MDRh"</code></pre>
+	-H "authorization: Basic MjQ2MmM5NmItNjQyNy00ZWZiLWFlZDctMTE4ZTIwYzJlOTk3OjhlODdmMGViYzUwZDEwZjFiYzk3MzQzMjlhOTkwMDE3OWI4NGNjZDM5ZTRkMDkyMGI5MDVjYzM1OWNmNmU5NGE2ZTc2MGJiZTNhMDg5MGM3"</code></pre>
 
 <p>
 	cURL Option 2: This cURL command encrypts your credentials with base-64 encryption

--- a/_includes/build/bcda_v2.html
+++ b/_includes/build/bcda_v2.html
@@ -19,13 +19,15 @@
             </tr>
             <tr>
                 <td>
-                    <code>curl -X GET 'https://api.bcda.cms.gov/api/v1/Patient/$export' \ 
-                        -H "accept: application/fhir+json" \ -H "Prefer: respond-async" \ 
+                    <code>curl -X GET 'https://api.bcda.cms.gov/api/v1/Patient/$export' \
+                        -H "accept: application/fhir+json" \
+                        -H "Prefer: respond-async" \
                         -H "Authorization: Bearer {access_token}"</code>
                 </td>
                 <td>
-                    <code>curl -X GET 'https://api.bcda.cms.gov/api/v2/Patient/$export' \ 
-                        -H "accept: application/fhir+json" \ -H "Prefer: respond-async" \ 
+                    <code>curl -X GET 'https://api.bcda.cms.gov/api/v2/Patient/$export' \
+                        -H "accept: application/fhir+json" \
+                        -H "Prefer: respond-async" \
                         -H "Authorization: Bearer {access_token}"</code>
                 </td>    
             </tr>

--- a/_includes/guide/bcda_v2.html
+++ b/_includes/guide/bcda_v2.html
@@ -20,15 +20,15 @@
         </tr>
         <tr>
             <td>
-                <code>curl -X GET 'https://sandbox.bcda.cms.gov/api/v1/Patient/$export' \ 
-                    -H "accept: application/fhir+json" \ 
-                    -H "Prefer: respond-async" \ 
+                <code>curl -X GET 'https://sandbox.bcda.cms.gov/api/v1/Patient/$export' 
+                    -H "accept: application/fhir+json" \
+                    -H "Prefer: respond-async" \
                     -H "Authorization: Bearer {access_token}"</code>
             </td>
             <td>
-                <code>curl -X GET 'https://sandbox.bcda.cms.gov/api/v2/Patient/$export' \ 
-                    -H "accept: application/fhir+json" \ 
-                    -H "Prefer: respond-async" \ 
+                <code>curl -X GET 'https://sandbox.bcda.cms.gov/api/v2/Patient/$export' \
+                    -H "accept: application/fhir+json" \
+                    -H "Prefer: respond-async" \
                     -H "Authorization: Bearer {access_token}"</code>
             </td>    
         </tr>

--- a/_includes/guide/bcda_v2.html
+++ b/_includes/guide/bcda_v2.html
@@ -20,7 +20,7 @@
         </tr>
         <tr>
             <td>
-                <code>curl -X GET 'https://sandbox.bcda.cms.gov/api/v1/Patient/$export' 
+                <code>curl -X GET 'https://sandbox.bcda.cms.gov/api/v1/Patient/$export' \
                     -H "accept: application/fhir+json" \
                     -H "Prefer: respond-async" \
                     -H "Authorization: Bearer {access_token}"</code>


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7198

## 🛠 Changes

- Update URL in instructions to point to `/auth/token`
- Update bearer string in instructions to match the client ID/secret in Option 2

## ℹ️ Context for reviewers

Noticed that these instructions are a little inaccurate and don't actually work. They should be updated so folks can successfully retrieve short-lived tokens in sandbox.

## ✅ Acceptance Validation

Validated by running the new cURL command locally.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.