### PR TITLE
Fix cURL command to get a sandbox token in try_the_api.html

### DIFF
--- a/_includes/guide/try_the_api.html
+++ b/_includes/guide/try_the_api.html
@@ -74,8 +74,7 @@
 	Sample cURL Command to Submit Credentials for an Access Token
 </h3>
 <pre><code>curl -d '' -X POST 'https://sandbox.bcda.cms.gov/auth/token' \
-
-	--user 2462c96b-6427-4efb-aed7-118e20c2e997:8e87f0ebc50d10f1bc9734329a9900179b84ccd39e4d0920b905cc359cf6e94a6e760bbe3a0890c7 \
+	--user 2462c96b-6427-4efb-aed7-118e20c2e997:8e87f0ebc50d10f1bc9734329a9900179b84ccd39e4d0920b905cc359cf6e94a6e760bbe3a0890c7 \        
 	-H "accept: application/json"</code></pre>
 
 <h3>

--- a/_includes/guide/try_the_api.html
+++ b/_includes/guide/try_the_api.html
@@ -74,7 +74,7 @@
 	Sample cURL Command to Submit Credentials for an Access Token
 </h3>
 <pre><code>curl -d '' -X POST 'https://sandbox.bcda.cms.gov/auth/token' \
-	--user 2462c96b-6427-4efb-aed7-118e20c2e997:8e87f0ebc50d10f1bc9734329a9900179b84ccd39e4d0920b905cc359cf6e94a6e760bbe3a0890c7 \        
+	--user 2462c96b-6427-4efb-aed7-118e20c2e997:8e87f0ebc50d10f1bc9734329a9900179b84ccd39e4d0920b905cc359cf6e94a6e760bbe3a0890c7 \
 	-H "accept: application/json"</code></pre>
 
 <h3>


### PR DESCRIPTION
Remove whitespace from sandbox token cURL command. Copy/Paste of this command failed due to the newline character

## 🎫 Ticket

~https://jira.cms.gov/browse/BCDA-xxx~

## 🛠 Changes

Remove whitespace from sandbox token cURL command. Copy/Paste this command was broken due to the newline

## ℹ️ Context for reviewers

@laurenkrugen-navapbc caught this broken command when walking through the documentation. The same command is used in [the build instructions](https://github.com/CMSgov/bcda-static-site/blob/deac7639b912dc016e30171a34d990a637be1ff7/_includes/build/access_token.html#L46-L48)

## ✅ Acceptance Validation

@laurenkrugen-navapbc has validated this cURL command during connectathon prep work

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
