### PR TITLE
BCDA-7333: Run a11y scans on PACA page

### DIFF
--- a/_includes/partial/faq.html
+++ b/_includes/partial/faq.html
@@ -1,14 +1,14 @@
 <div>
-  <h4>1) What are BCDA (Beneficiary Claims Data API) Partially Adjudicated Claims data?
-  </h4>
+  <div class="ds-u-font-weight--bold">1) What are BCDA (Beneficiary Claims Data API) Partially Adjudicated Claims data?
+  </div>
   <p>The BCDA Partially Adjudicated Claims data can be used to increase care coordination, improve healthcare outcomes, and reduce overall healthcare cost for enrollees. It does this by reducing the time to access Parts A and B Fee-for-Service (FFS) claims from typically up to 14 days for adjudicated claims, to 2-4 days using partially adjudicated claims data. Partially adjudicated claims are claims that have entered the Medicare processing system but are not fully paid or processed by CMS. Part D (drug related) and Durable Medical Equipment (DME) are not included in partially adjudicated claims. The BCDA Partially Adjudicated Claims data is accessible through BCDA. This capability is available to Realizing Equity, Access, and Community Health (REACH) Accountable Care Organizations (ACOs). The initial release provides these REACH ACOs with an opportunity to streamline their clinical care processes. REACH ACOs with BCDA credentials who access BCDA V2 will, by default, also retrieve partially adjudicated claims through the Claim and ClaimResponse resource types.
   </p>
-  <h4>2) What FHIR® resources can I access in the BCDA production environment?
-  </h4>
+  <div class="ds-u-font-weight--bold">2) What FHIR® resources can I access in the BCDA production environment?
+  </div>
   <p>REACH ACOs with BCDA credentials can currently access adjudicated claims data through three (3) bulk Fast Healthcare Interoperability Resource (FHIR®) resource types: Explanation of Benefit, Patient, and Coverage. The BCDA Partially Adjudicated Claims functionality exposes the following two (2) additional bulk FHIR® resource types: Claim and ClaimResponse, so that REACH ACOs with BCDA credentials can also access partially adjudicated claims data.
   </p>
-  <h4>3) What are the BCDA API endpoints for the BCDA Partially Adjudicated Claims?
-  </h4>
+  <div class="ds-u-font-weight--bold">3) What are the BCDA API endpoints for the BCDA Partially Adjudicated Claims?
+  </div>
   <p>The endpoints that expose BCDA Partially Adjudicated Claims are as follows. 
   </p>
   <ul>
@@ -21,41 +21,41 @@
   </ul>
   <p>These endpoints are used for adjudicated claims as well.
   </p>
-  <h4>4) Where can I find the Data Dictionary to learn more about the data fields that are included in BCDA Partially Adjudicated Claims data?
-  </h4>
+  <div class="ds-u-font-weight--bold">4) Where can I find the Data Dictionary to learn more about the data fields that are included in BCDA Partially Adjudicated Claims data?
+  </div>
   <p>The Data Dictionary for the BCDA Partially Adjudicated Claims data can be found <a href="/assets/data/BCDA_Partially_Adjudicated_Data_Dictionary_v1.0.0_2023_05_16.xlsx" target="blank" class="in-text__link">here</a>.
   </p>
-  <h4>5) In analyzing events like tests and referrals for Low-Value Care patients, is there any benefit to using partially adjudicated claims if the event was already completed?
-  </h4>
+  <div class="ds-u-font-weight--bold">5) In analyzing events like tests and referrals for Low-Value Care patients, is there any benefit to using partially adjudicated claims if the event was already completed?
+  </div>
   <p>Using partially adjudicated claims data for simple, one-stage events, like Vitamin D testing, will not provide much benefit since the event has already been completed and the payment has been made. If the event becomes a multi-event with a potentially high cost, you may want to look into partially adjudicated claims data early on.
   </p>
-  <h4>6) What’s the best way for us to get support?
-  </h4>
+  <div class="ds-u-font-weight--bold">6) What’s the best way for us to get support?
+  </div>
   <p>Email is the best way to get in touch with the BCDA Project Team <a href="mailto:bcapi@cms.hhs.gov">bcapi@cms.hhs.gov</a>. We are also available to answer questions in the BCDA Google Group which can be found <a href="https://groups.google.com/u/0/g/bc-api" target="_self" class="in-text__link">here</a>.
   </p>
-  <h4>7) Why do I get connection timeout issues with my credentials in production?
-  </h4>
+  <div class="ds-u-font-weight--bold">7) Why do I get connection timeout issues with my credentials in production?
+  </div>
   <p>Please make sure the IP address you are connecting with is whitelisted in 4i, found <a href="https://4innovation.cms.gov/" target="_self" class="in-text__link">here</a>.
   </p>
-  <h4>8) What do I need to be able to access the BCDA (Beneficiary Claims Data API) Partially Adjudicated Claims data in the Production environment?
-  </h4>
+  <div class="ds-u-font-weight--bold">8) What do I need to be able to access the BCDA (Beneficiary Claims Data API) Partially Adjudicated Claims data in the Production environment?
+  </div>
   <p>There are 5 basic things that are required to access the BCDA (Beneficiary Claims Data API) Partially Adjudicated Claims data?
   </p>
   {% include partial/eligibility_requirements.html %}
-  <h4>9) What version of the BCDA API do I need to access the BCDA Partially Adjudicated Claims sandbox?
-  </h4>
+  <div class="ds-u-font-weight--bold">9) What version of the BCDA API do I need to access the BCDA Partially Adjudicated Claims sandbox?
+  </div>
   <p>BCDA API version 2 (V2) is required to access the BCDA Partially Adjudicated Claims data.
   </p>
-  <h4>10) How do I access the sandbox for the BCDA Partially Adjudicated Claims data?
-  </h4>
+  <div class="ds-u-font-weight--bold">10) How do I access the sandbox for the BCDA Partially Adjudicated Claims data?
+  </div>
   <p>Currently, the BCDA Partially Adjudicated Claims Data is only available to REACH ACOs with BCDA credentials. BCDA has made synthetic data sets available for anyone to test partially adjudicated claims in the BCDA Sandbox. You can learn more about the BCDA sandbox access <a href="/guide.html#try-the-api" target="_self" class="in-text__link">here</a>.
   </p>
-  <h4>11) How do I obtain credentials to access the BCDA (Beneficiary Claims Data API) Partially Adjudicated Claims Sandbox?
-  </h4>
+  <div class="ds-u-font-weight--bold">11) How do I obtain credentials to access the BCDA (Beneficiary Claims Data API) Partially Adjudicated Claims Sandbox?
+  </div>
   <p>The credentials for BCDA Sandbox are available on the BCDA website, found <a href="/guide.html#try-the-api" target="_self" class="in-text__link">here</a>.
   </p>
-  <h4>12) For REACH ACOs who would like access to partially adjudicated claims, do they need to update their credentials to access Version 2 (V2) of the BDCA API?
-  </h4>
+  <div class="ds-u-font-weight--bold">12) For REACH ACOs who would like access to partially adjudicated claims, do they need to update their credentials to access Version 2 (V2) of the BDCA API?
+  </div>
   <p>Access to the Claim and ClaimResponse resources is handled within BCDA on a per ACO (Accountable Care Organization) ID level. There are no required changes to credentials for those REACH ACOs who would like access to the V2 endpoint. The BCDA V2 service supports the same functionality as V1 API endpoints in both the sandbox and production API environments. All V2 endpoints should work as described in the existing BCDA documentation. To transition from V1 to your BCDA V2 endpoints, replace ‘v1’ in the API call URLs with ‘v2’, as in the cURL example below:
   </p>
 <pre><code>curl -X GET 'https://sandbox.bcda.cms.gov/api/v1/Patient/$export' \
@@ -64,48 +64,48 @@
 -H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>" \
 -v
 </code></pre>
-  <h4>13) Are partially adjudicated claims received after a supplier’s orders are completed and the claims are submitted for payment? Or, are they received in a pre-authorization form? For example, if we place an order for an x-ray and then the x-ray supplier first submits a pre-op before they even see the patient, would we be receiving any of those before the event actually happens or is partially adjudicated data only available after the fact?
-  </h4>
+  <div class="ds-u-font-weight--bold">13) Are partially adjudicated claims received after a supplier’s orders are completed and the claims are submitted for payment? Or, are they received in a pre-authorization form? For example, if we place an order for an x-ray and then the x-ray supplier first submits a pre-op before they even see the patient, would we be receiving any of those before the event actually happens or is partially adjudicated data only available after the fact?
+  </div>
   <p>In Medicare Fee-for-Service (FFS), in the timeline of a supplier order and partially adjudicated data, there is no pre-authorization information available. In BCDA, we only see partially adjudicated claims for actual claims, not for the pre-authorization type or a pre-determination type.
   </p>
-  <h4>14A) What is the estimated amount of data we will receive through partially adjudicated claims? How does that compare to adjudicated claims?
-  </h4>
+  <div class="ds-u-font-weight--bold">14A) What is the estimated amount of data we will receive through partially adjudicated claims? How does that compare to adjudicated claims?
+  </div>
   <p>As for the amount of data you can expect between adjudicated claims and partially adjudicated claims, partially adjudicated claims will experience iterations during their journey, potentially causing them to look larger in the database than the adjudicated claims. By nature, you're getting access and visibility into the claim as it moves along. Every time an adjudicated claims goes to a different step, we are including an update message in the data. The volume of claims data you're going to see depends on how many MBIs (Medicare Beneficiary Identifiers) you have access to, given the number of enrollees attributed to your REACH ACO, as well as the number of updates a given claim receives. You could consider using a database query (e.g. on the number of enrollees) in your environment for more information on your specific needs.
   </p>
-  <h4>14B) Can you please provide some guidance in terms of a ballpark ratio for every Explanation of Benefits (EOB) that one would expect to see, e.g. whether it's five, ten, or five hundred passes for a Claim or ClaimResponse?
-  </h4>
+  <div class="ds-u-font-weight--bold">14B) Can you please provide some guidance in terms of a ballpark ratio for every Explanation of Benefits (EOB) that one would expect to see, e.g. whether it's five, ten, or five hundred passes for a Claim or ClaimResponse?
+  </div>
   <p>One portion of the volume of data is tied to a claims journey during the adjudication process. During the claims journey, claims can have many iterations. Through the three (3) phases, a claim can go through a rapid number of iterations as it is denied and reprocessed. With partially adjudicated claims, you can get access and visibility during the claim’s journey. Every time the claim travels through a different step, you can see an updated message in a partially adjudicated claims data. For the entire claim, we have seen on average, about 12 million MCS (Multi-Carrier System) claims and 5 or 6 million FISS (Fiscal Intermediary Standard System) claims per day. This is approximately 160,000 each day and 18 million adjustments throughout the week. You will see a significant increase in volume if you are keeping every single version as the ClaimResponse evolves. The second part of the volume for partially adjudicated claims data depends on how many MBIs to which an organization has access.
   </p>
-  <h4>14C) How many updates to a claim can a user expect to see?
-  </h4>
+  <div class="ds-u-font-weight--bold">14C) How many updates to a claim can a user expect to see?
+  </div>
   <p>All claims data that appear in the claims submission process are captured, this includes every change that could come in from upstream claims data. Not all changes are data fields that are visible to end users. This means that a change could occur, but then the data won't reflect it. More in-depth queries would need to be done to determine this information.
   </p>
-  <h4>14D) If we get the Claim Resource and ClaimResponse Resource, does that negate the need for the Explanation of Benefit (EOB) Resource?
-  </h4>
+  <div class="ds-u-font-weight--bold">14D) If we get the Claim Resource and ClaimResponse Resource, does that negate the need for the Explanation of Benefit (EOB) Resource?
+  </div>
   <p>This would not negate the need for the EOB Resource. The Claim and ClaimResponse resources contain a subset of data elements that are in the EOB. So if you would like to get the full set of data elements, you would need to have the EoB resource.
   </p>
-  <h4>14E) How often do you recommend we query the Explanation of Benefits (EOB), Patient and Coverage resources? How often should we query the Claim and ClaimResponse resources?
-  </h4>
+  <div class="ds-u-font-weight--bold">14E) How often do you recommend we query the Explanation of Benefits (EOB), Patient and Coverage resources? How often should we query the Claim and ClaimResponse resources?
+  </div>
   <p>We cannot make a recommendation on the frequency you should query the Explanation of Benefits (EOB), Patient and Coverage resources. These resources are typically updated weekly. The Claim and ClaimResponse resources are typically updated every 2 to 4 days.
   </p>
-  <h4>15) Does every Claim have a corresponding ClaimResponse? Are version numbers present?
-  </h4>
+  <div class="ds-u-font-weight--bold">15) Does every Claim have a corresponding ClaimResponse? Are version numbers present?
+  </div>
   <p>Every Claim has one and only one ClaimResponse. Version numbers are not currently provided for claims. We can explore providing versioning in the future based on interest.
   </p>
-  <h4>16) Will you be releasing additional data elements for partially adjudicated claims data in the future?
-  </h4>
+  <div class="ds-u-font-weight--bold">16) Will you be releasing additional data elements for partially adjudicated claims data in the future?
+  </div>
   <p>The BCDA Partially Adjudicated Project Team is continuously working to source, ingest (import data), and add new data fields to the API. Please let us know if there are any fields that you would like to see us add.
   </p>
-  <h4>17) Are the Claim ID and Claim Group ID fields visible in partially adjudicated claims data?
-  </h4>
+  <div class="ds-u-font-weight--bold">17) Are the Claim ID and Claim Group ID fields visible in partially adjudicated claims data?
+  </div>
   <p>These two fields are not present in the partially adjudicated data fields at this time. We are always looking for feedback to help improve the availability of data elements that can improve healthcare coordination and patient outcomes.
   </p>
-  <h4>18) Why do I get connection timeout issues with my credentials in production when using a 3rd party web-based REST client?
-  </h4>
+  <div class="ds-u-font-weight--bold">18) Why do I get connection timeout issues with my credentials in production when using a 3rd party web-based REST client?
+  </div>
   <p>Please be very careful using 3rd party web-based clients that are not in your control. You may unintentionally be sharing your credentials with them to make REST calls on your behalf; thus becoming a security risk. We recommend speaking with your technical team to assist you in using secure REST client tools that do not leak data. Additionally; you will need to make sure that the 4i IP whitelisting rules apply to whatever tool you are using.
   </p>
-  <h4>19) The *.ndjson files downloaded are difficult to parse. Can I use a 3rd party website tool to view them more easily?
-  </h4>
+  <div class="ds-u-font-weight--bold">19) The *.ndjson files downloaded are difficult to parse. Can I use a 3rd party website tool to view them more easily?
+  </div>
   <p>Again, please be very careful in using 3rd party website utilities that are outside of the control of your REACH ACO. You may be sharing sensitive PII/PHI patient data with these websites. We recommend speaking with your technical team to assist you in using secure parsing tools that do not leak any data.
   </p>
 </div>

--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -2,8 +2,7 @@
 
 set -eo pipefail
 
-docker_cleanup()
-{
+docker_cleanup() {
     docker-compose down
 }
 
@@ -16,7 +15,7 @@ test() {
     docker-compose run -u "$(id -u "${USER}")":"$(id -g "${USER}")" --publish 4000:4000 --rm --entrypoint "bundle exec jekyll serve -H 0.0.0.0" -d static_site
     sleep 20
     curl localhost:4000 | grep "Join the Google Group"
-    
+
     # Perform accessibility scan
     TARGET_TEST_ENV=http://host.docker.internal:4000
     TARGETS_TO_SCAN="${TARGET_TEST_ENV}"
@@ -24,6 +23,7 @@ test() {
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/build.html"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/data.html"
     TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/updates.html"
+    TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/partial.html"
     docker run --add-host=host.docker.internal:host-gateway --init --rm --cap-add=SYS_ADMIN orenfromberg/axe-puppeteer-ci:1.0.0@sha256:f83527a3ae8ab74088c001abfe44836946ba73f0afbbf460447f8a0c40281e70 ${TARGETS_TO_SCAN}
 }
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7333

## 🛠 Changes

- Add partial.html to list of pages for a11y scanning
- Replace h4 tags with bolded div text

## ℹ️ Context for reviewers

- A new page was added, but it is not being accessibility-scanned.
- The h4 tags violate the heading level checks from axe which state that headings should only increase by one. The h4 tags in the FAQ were following the h1 tag for the section title. Instead, replace them with bolded divs. Note that the h4 tag does not actually apply any font-size styling, so we don't need to use the `ds-u-font-size--h4` class.

## ✅ Acceptance Validation

- PR checks should pass.
- Verified FAQ output looks the same:

|Before|After|
|---|---|
|<img width="803" alt="Screen Shot 2023-08-22 at 12 28 47 PM" src="https://github.com/CMSgov/bcda-static-site/assets/2308368/f9d26e7c-b90d-44d4-822d-0e58e3ee47df">|<img width="800" alt="Screen Shot 2023-08-22 at 12 28 56 PM" src="https://github.com/CMSgov/bcda-static-site/assets/2308368/d53efc8d-9be8-452a-b8af-ee38082ecd0c">|



## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.