### PR TITLE
Fix footer link for Plain Writing

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -41,7 +41,7 @@
         <li><a target="_blank" rel="noopener" href="https://oig.hhs.gov/">Inspector General</a></li>
         <li><a target="_blank" rel="noopener" href="https://www.cms.gov/About-CMS/Agency-Information/Aboutwebsite/NoFearAct.html">No
             Fear Act</a></li>
-        <li><a target="_blank" rel="noopener" href="https://www.medicare.gov/about-us/plain-writing/plain-writing.html">Plain
+        <li><a target="_blank" rel="noopener" href="https://www.medicare.gov/about-us/plain-writing">Plain
             Writing</a></li>
         <li><a title="Privacy settings" data-privacy-policy="modal-trigger-footer" onclick="utag.gdpr.showConsentPreferences()">Privacy Settings</a></li>
         <li><a target="_blank" rel="noopener" href="https://www.usa.gov/">USA.gov</a></li>


### PR DESCRIPTION
## 🎫 Ticket

~https://jira.cms.gov/browse/BCDA-xxx~

## 🛠 Changes

Fixed a broken link in the footer to the plain writing guide.

## ℹ️ Context for reviewers

Clicking the "Plain Writing" link in the footer, brings the user to a 404 page
<img width="1157" alt="Screenshot 2023-09-14 at 14 30 56" src="https://github.com/CMSgov/bcda-static-site/assets/10712873/0cdbe697-1a14-4f28-bf0b-a2ef72c721d1">
<img width="1459" alt="Screenshot 2023-09-14 at 14 30 20" src="https://github.com/CMSgov/bcda-static-site/assets/10712873/847e5415-725b-45d6-9413-1f3a5a5c6e20">

## ✅ Acceptance Validation

The updated link directs to 
<img width="1461" alt="Screenshot 2023-09-14 at 14 28 19" src="https://github.com/CMSgov/bcda-static-site/assets/10712873/29e658c6-6bdf-40b9-ac7b-a56f3c2e53c5">

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
