### PR TITLE
BCDA-7331: Update cURL commands to use V2 and other recommended options

### DIFF
--- a/_includes/build/attribution_status.html
+++ b/_includes/build/attribution_status.html
@@ -7,14 +7,14 @@
 <h3>Step 2: Send a Request to the Attribution Status Endpoint</h3>
 
 <h4>Requests to check the last updated date of your attribution data</h4>  
-<pre><code>GET /api/v1/attribution_status</code></pre>
+<pre><code>GET /api/v2/attribution_status</code></pre>
 
 <h4>Request Headers</h4>
 <pre><code>Authorization: Bearer <span style="color: #046B99;">{access_token}</span>
 Accept: application/json</code></pre>
 
 <h4>cURL Command to retrieve the attribution status</h4>
-<pre><code>curl -X GET 'https://api.bcda.cms.gov/api/v1/attribution_status' \
+<pre><code>curl -X GET 'https://api.bcda.cms.gov/api/v2/attribution_status' \
     -H "accept: application/json" \
     -H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"</code></pre>
 

--- a/_includes/build/bcda_v2.html
+++ b/_includes/build/bcda_v2.html
@@ -20,13 +20,13 @@
             </tr>
             <tr>
                 <td>
-                    <code>curl -X GET 'https://sandbox.bcda.cms.gov/api/v2/Group/all/$export' \
+                    <code>curl -X GET 'https://api.bcda.cms.gov/api/v2/Group/all/$export' \
                         -H "accept: application/fhir+json" \
                         -H "Prefer: respond-async" \
                         -H "Authorization: Bearer {access_token}"</code>
                 </td>
                 <td>
-                    <code>curl -X GET 'https://sandbox.bcda.cms.gov/api/v1/Group/all/$export' \
+                    <code>curl -X GET 'https://api.bcda.cms.gov/api/v1/Group/all/$export' \
                         -H "accept: application/fhir+json" \
                         -H "Prefer: respond-async" \
                         -H "Authorization: Bearer {access_token}"</code>

--- a/_includes/build/bcda_v2.html
+++ b/_includes/build/bcda_v2.html
@@ -20,16 +20,18 @@
             </tr>
             <tr>
                 <td>
-                    <code>curl -X GET 'https://api.bcda.cms.gov/api/v2/Group/all/$export' \
-                        -H "accept: application/fhir+json" \
-                        -H "Prefer: respond-async" \
-                        -H "Authorization: Bearer {access_token}"</code>
+                    <pre><code>curl -X GET 'https://api.bcda.cms.gov/api/v2/Group/all/$export' \
+-H "accept: application/fhir+json" \
+-H "Prefer: respond-async" \
+-H "Authorization: Bearer {access_token}"
+-v</code></pre>
                 </td>
                 <td>
-                    <code>curl -X GET 'https://api.bcda.cms.gov/api/v1/Group/all/$export' \
-                        -H "accept: application/fhir+json" \
-                        -H "Prefer: respond-async" \
-                        -H "Authorization: Bearer {access_token}"</code>
+                    <pre><code>curl -X GET 'https://api.bcda.cms.gov/api/v1/Group/all/$export' \
+-H "accept: application/fhir+json" \
+-H "Prefer: respond-async" \
+-H "Authorization: Bearer {access_token}"
+-v</code></pre>
                 </td>  
             </tr>
         </table>

--- a/_includes/build/bcda_v2.html
+++ b/_includes/build/bcda_v2.html
@@ -3,6 +3,7 @@
     BCDA will support all functionality for both V1 and V2 of the API  for the foreseeable future; however, 
     upgrading to BCDA’s V2 API ensures your product is aligned with the latest industry standards. 
     For more information on BCDA V2, please visit the <a href="https://github.com/CMSgov/beneficiary-fhir-data/wiki/Migrating-to-V2-FAQ" target="_blank" class="in-text__link">CMS V2 API FAQ Documentation</a>. 
+    For more information on how BCDA data will change in BCDA V2, please visit the BCDA <a href="/data.html" target="_self" class="in-text__link">Understanding the Data page</a>. 
 </p>
 <h2>
 	How will BCDA V2 change the way I interact with the BCDA API?
@@ -11,26 +12,27 @@
     BCDA V2 supports the same functionality as V1 API endpoints in both the Sandbox and Production API environments. If you wish to transition your implementation to utilize BCDA V2 endpoints instead of V1, replace ‘v1’ in API call URLs with ‘v2’. Here is an example:
 </p>
 <p>
-    <div style="overflow-x:auto;">
+    <div style="overflow-x:auto;">    
         <table aria-label="Example Curl commands">
             <tr>
-                <th>Sample cURL Command in BCDA V1:</th>
                 <th>Sample cURL Command in BCDA V2:</th>
+                <th>Sample cURL Command in BCDA V1:</th>
             </tr>
             <tr>
                 <td>
-                    <code>curl -X GET 'https://api.bcda.cms.gov/api/v1/Patient/$export' \
+                    <code>curl -X GET 'https://sandbox.bcda.cms.gov/api/v2/Group/all/$export' \
                         -H "accept: application/fhir+json" \
                         -H "Prefer: respond-async" \
                         -H "Authorization: Bearer {access_token}"</code>
                 </td>
                 <td>
-                    <code>curl -X GET 'https://api.bcda.cms.gov/api/v2/Patient/$export' \
+                    <code>curl -X GET 'https://sandbox.bcda.cms.gov/api/v1/Group/all/$export' \
                         -H "accept: application/fhir+json" \
                         -H "Prefer: respond-async" \
                         -H "Authorization: Bearer {access_token}"</code>
-                </td>    
+                </td>  
             </tr>
         </table>
-    </div>
-</p>
+    </div>    
+    </p>
+    

--- a/_includes/build/bcda_v2.html
+++ b/_includes/build/bcda_v2.html
@@ -23,14 +23,14 @@
                     <pre><code>curl -X GET 'https://api.bcda.cms.gov/api/v2/Group/all/$export' \
 -H "accept: application/fhir+json" \
 -H "Prefer: respond-async" \
--H "Authorization: Bearer {access_token}"
+-H "Authorization: Bearer {access_token}" \
 -v</code></pre>
                 </td>
                 <td>
                     <pre><code>curl -X GET 'https://api.bcda.cms.gov/api/v1/Group/all/$export' \
 -H "accept: application/fhir+json" \
 -H "Prefer: respond-async" \
--H "Authorization: Bearer {access_token}"
+-H "Authorization: Bearer {access_token}" \
 -v</code></pre>
                 </td>  
             </tr>

--- a/_includes/build/cancelling_jobs.html
+++ b/_includes/build/cancelling_jobs.html
@@ -5,7 +5,7 @@
 <h3>Step 2: Send a Request to Cancel a Job</h3>
 
 <h4>Request to Cancel a Job</h4>
-      <pre><code>DELETE /api/v1/jobs/{jobId}</code></pre>
+      <pre><code>DELETE /api/v2/jobs/{jobId}</code></pre>
 
 <h4>Request Headers</h4>
 <pre><code>Authorization: Bearer <span style="color: #046B99;">{access_token}</span>

--- a/_includes/build/jobs_history.html
+++ b/_includes/build/jobs_history.html
@@ -7,7 +7,7 @@
 <h3>Step 2: Send a Request to the Jobs Endpoint</h3>
 
 <h4>Requests to retrieve data on all past jobs</h4>  
-<pre><code>GET /api/v1/jobs</code></pre>
+<pre><code>GET /api/v2/jobs</code></pre>
 
 <h4>Request Headers</h4>
 <pre><code>Authorization: Bearer <span style="color: #046B99;">{access_token}</span>
@@ -15,7 +15,7 @@ Accept: application/fhir+json
 Prefer: respond-async</code></pre>
 
 <h4>cURL Command to check the job status</h4>
-<pre><code>curl -X GET 'https://api.bcda.cms.gov/api/v1/jobs' \
+<pre><code>curl -X GET 'https://api.bcda.cms.gov/api/v2/jobs' \
     -H "accept: application/fhir+json" \
     -H "Prefer: respond-async" \
     -H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"</code></pre>
@@ -31,7 +31,7 @@ Prefer: respond-async</code></pre>
                 },
                 "identifier":[
                     {
-                        "system":"http://bcda.cms.gov/api/v1/jobs",
+                        "system":"http://bcda.cms.gov/api/v2/jobs",
                         "use":"official",
                         "value":"1"
                     }
@@ -76,7 +76,7 @@ Prefer: respond-async</code></pre>
 </p>
 
 <p>
-    For example, if your organization had jobs Archived in the BCDA system, you could make a filtered request for those as follows: <code>GET /api/v1/Jobs?_status=Archived</code>. You would receive a list of jobs with the status “Completed”. All of these jobs were Archived in the BCDA system. If your organization also had jobs with the end state of Expired or Completed in the BCDA system, they would also hold the status of Completed. But, they would not be returned in your request for Archived jobs.
+    For example, if your organization had jobs Archived in the BCDA system, you could make a filtered request for those as follows: <code>GET /api/v2/Jobs?_status=Archived</code>. You would receive a list of jobs with the status “Completed”. All of these jobs were Archived in the BCDA system. If your organization also had jobs with the end state of Expired or Completed in the BCDA system, they would also hold the status of Completed. But, they would not be returned in your request for Archived jobs.
 </p>
 
 <p>

--- a/_includes/build/request_metadata.html
+++ b/_includes/build/request_metadata.html
@@ -12,12 +12,12 @@
 	Metadata Request
 </h3>
 
-<pre><code>GET /api/v1/metadata</code></pre>
+<pre><code>GET /api/v2/metadata</code></pre>
 
 <h3>
 	Metadata cURL Command
 </h3>
-<pre><code>curl https://api.bcda.cms.gov/api/v1/metadata</code></pre>
+<pre><code>curl https://api.bcda.cms.gov/api/v2/metadata</code></pre>
 
 <h3>
 	Metadata Response Example

--- a/_includes/build/requesting_data_all_three.html
+++ b/_includes/build/requesting_data_all_three.html
@@ -1,8 +1,8 @@
 <div class="ds-c-alert ds-c-alert--hide-icon">
     	<div class="ds-c-alert__body">
-    	  <h3 class="ds-c-alert__heading"> The examples below are for the /Patient endpoint.</h3>
+    	  <h3 class="ds-c-alert__heading"> The examples below are for the /Group endpoint.</h3>
     	    <p class="ds-c-alert__text">
-    	      We have provided a few examples below in which we show retrieving only certain resource types from the /Patient endpoint. The request and cURL statements can be altered to retrieve any combination of resource types and resource types from the /Group endpoint as needed.
+    	      We have provided a few examples below in which we show retrieving only certain resource types from the /Group endpoint. The request and cURL statements can be altered to retrieve any combination of resource types and resource types from the /Patient endpoint as needed.
     	  	</p>
     </div>
 </div>
@@ -15,9 +15,9 @@
 
 <h4>Requests to start a job</h4>
 <ol>
-	<li><pre><code>GET /api/v1/Patient/$export</code></pre></li>
-	<li><pre><code>GET /api/v1/Patient/$export?_type=ExplanationOfBenefit,Patient</code></pre></li>
-	<li><pre><code>GET /api/v1/Patient/$export?_type=Patient</code></pre></li>
+	<li><pre><code>GET /api/v2/Group/all/$export</code></pre></li>
+	<li><pre><code>GET /api/v2/Group/all/$export?_type=ExplanationOfBenefit,Patient</code></pre></li>
+	<li><pre><code>GET /api/v2/Group/all/$export?_type=Patient</code></pre></li>
 </ol>
 
 <h4>Request Headers</h4>
@@ -29,19 +29,19 @@ Prefer: respond-async
 <h4>cURL Commands to start a job</h4>
 <ol>
 	<li>
-		<pre><code>curl -X GET 'https://api.bcda.cms.gov/api/v1/Patient/$export' \
+		<pre><code>curl -X GET 'https://api.bcda.cms.gov/api/v2/Group/all/$export' \
 	-H "accept: application/fhir+json" \
 	-H "Prefer: respond-async" \
 	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"</code></pre>
 	</li>
 	<li>
-		<pre><code>curl -X GET 'https://api.bcda.cms.gov/api/v1/Patient/$export?_type=ExplanationOfBenefit,Patient' \
+		<pre><code>curl -X GET 'https://api.bcda.cms.gov/api/v2/Group/all/$export?_type=ExplanationOfBenefit,Patient' \
 	-H "accept: application/fhir+json" \
 	-H "Prefer: respond-async" \
 	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"</code></pre>
 	</li>
 	<li>
-		<pre><code>curl -X GET 'https://api.bcda.cms.gov/api/v1/Patient/$export?_type=Patient' \
+		<pre><code>curl -X GET 'https://api.bcda.cms.gov/api/v2/Group/all/$export?_type=Patient' \
 	-H "accept: application/fhir+json" \
 	-H "Prefer: respond-async" \
 	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"</code></pre>
@@ -55,7 +55,7 @@ Prefer: respond-async
 	<pre><code>429 Too Many Requests</code></pre>
 
 <h4>Response Headers</h4>
-	<pre><code>Content-Location: https://api.bcda.cms.gov/api/v1/jobs/42</code></pre>
+	<pre><code>Content-Location: https://api.bcda.cms.gov/api/v2/jobs/42</code></pre>
 
 <h4>Start a Job Explanation</h4>
 	<p>This operation will start a data export job. We have provided three example requests and three example cURL statements to start a job for:</p>
@@ -85,21 +85,21 @@ Prefer: respond-async
 <h3 id="checkJob">Step 3: Check the job status</h3>
 
 <h4>Request to check the job status</h4>
-	<pre><code>GET https://api.bcda.cms.gov/api/v1/jobs/42</code></pre>
+	<pre><code>GET https://api.bcda.cms.gov/api/v2/jobs/42</code></pre>
 
 <h4>Request Headers</h4>
 	<pre><code>Authorization: Bearer <span style="color: #046B99;">{access_token}</span>
 Accept: application/fhir+json</code></pre>
 
 <h4>cURL Command to check the job status</h4>
-	<pre><code>curl -X GET 'https://api.bcda.cms.gov/api/v1/jobs/42' \
+	<pre><code>curl -X GET 'https://api.bcda.cms.gov/api/v2/jobs/42' \
 	-H "accept: application/fhir+json" \
 	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"</code></pre>
 
 <h4>Response Example: Completed Job</h4>
 	<pre><code>{
   "transactionTime": "2019-12-09T20:44:01.705398Z",
-  "request": "https://api.bcda.cms.gov/api/v1/Patient/$export",
+  "request": "https://api.bcda.cms.gov/api/v2/Group/all/$export",
   "requiresAccessToken": true,
   "output": [
     {

--- a/_includes/build/requesting_data_runouts.html
+++ b/_includes/build/requesting_data_runouts.html
@@ -6,9 +6,9 @@
 
 <h4>Requests to start a job</h4>
 <ol>
-	<li><pre><code>GET /api/v1/Group/runout/$export</code></pre></li>
-	<li><pre><code>GET /api/v1/Group/runout/$export?_type=ExplanationOfBenefit,Patient</code></pre></li>
-	<li><pre><code>GET /api/v1/Group/runout/$export?_type=Patient</code></pre></li>
+	<li><pre><code>GET /api/v2/Group/runout/$export</code></pre></li>
+	<li><pre><code>GET /api/v2/Group/runout/$export?_type=ExplanationOfBenefit,Patient</code></pre></li>
+	<li><pre><code>GET /api/v2/Group/runout/$export?_type=Patient</code></pre></li>
 </ol>
 
 <h4>Request Headers</h4>
@@ -20,19 +20,19 @@ Prefer: respond-async
 <h4>cURL Commands to start a job</h4>
 <ol>
 	<li>
-		<pre><code>curl -X GET 'https://api.bcda.cms.gov/api/v1/Group/runout/$export' \
+		<pre><code>curl -X GET 'https://api.bcda.cms.gov/api/v2/Group/runout/$export' \
 	-H "accept: application/fhir+json" \
 	-H "Prefer: respond-async" \
 	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"</code></pre>
 	</li>
 	<li>
-		<pre><code>curl -X GET 'https://api.bcda.cms.gov/api/v1/Group/runout/$export?_type=ExplanationOfBenefit,Patient' \
+		<pre><code>curl -X GET 'https://api.bcda.cms.gov/api/v2/Group/runout/$export?_type=ExplanationOfBenefit,Patient' \
 	-H "accept: application/fhir+json" \
 	-H "Prefer: respond-async" \
 	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"</code></pre>
 	</li>
 	<li>
-		<pre><code>curl -X GET 'https://api.bcda.cms.gov/api/v1/Group/runout/$export?_type=Patient' \
+		<pre><code>curl -X GET 'https://api.bcda.cms.gov/api/v2/Group/runout/$export?_type=Patient' \
 	-H "accept: application/fhir+json" \
 	-H "Prefer: respond-async" \
 	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"</code></pre>
@@ -43,7 +43,7 @@ Prefer: respond-async
 	<pre><code>202 Accepted</code></pre>
 
 <h4>Response Headers</h4>
-	<pre><code>Content-Location: https://api.bcda.cms.gov/api/v1/jobs/42</code></pre>
+	<pre><code>Content-Location: https://api.bcda.cms.gov/api/v2/jobs/42</code></pre>
 
 <h4>Start a Job using 'runout' with /Group Explanation</h4>
 	<p>This operation will start a data export job. We have provided three example requests and three example cURL statements to start a job for:</p>
@@ -59,7 +59,7 @@ Prefer: respond-async
 		Your access token is required and set as a header. Accept and Prefer headers are also required. The dollar sign ('$') before the word "export" in the URL indicates that the endpoint is an action rather than a resource. The format is defined by the FHIR Bulk Data Export spec.
 	</p>
 	<p>
-		If the request was successful, a 202 Accepted response code will be returned and the response will include a Content-Location header. The value of the Content-Location header indicates the location to check for job status and outcome. In the example header below, the number 42 in the URL represents the ID of the export job. The claims returned in the job will be filtered to have a serviceDate of 12/31/2020 or before.
+		If the request was successful, a 202 Accepted response code will be returned and the response will include a Content-Location header. The value of the Content-Location header indicates the location to check for job status and outcome. In the example header above, the number 42 in the URL represents the ID of the export job. The claims returned in the job will be filtered to have a serviceDate of 12/31/2020 or before.
 	</p>
 	<p>
 		If you're already requesting data from one endpoint and try to request data from that endpoint again while the first request is processing, you'll receive a 429 Too Many Requests error.

--- a/_includes/build/requesting_filtered_data_since_Group.html
+++ b/_includes/build/requesting_filtered_data_since_Group.html
@@ -8,7 +8,7 @@
 <h3>Step 2: Start a job</h3>
 
 <h4>Request to Start a job using the _since parameter within the /Group endpoint</h4>
-	<pre><code>GET /api/v1/Group/all/$export?_type=Patient&_since=2020-02-13T08:00:00.000-05:00</code></pre>
+	<pre><code>GET /api/v2/Group/all/$export?_type=Patient&_since=2020-02-13T08:00:00.000-05:00</code></pre>
 
 <h4>Request Headers</h4>
 <pre><code>Authorization: Bearer <span style="color: #046B99;">{access_token}</span>
@@ -17,7 +17,7 @@ Prefer: respond-async
 </code></pre>
 
 <h4>cURL Command using the _since parameter within the /Group endpoint</h4>
-	<pre><code>curl -X GET 'https://api.bcda.cms.gov/api/v1/Group/all/$export?_type=Patient&_since=2020-02-13T08:00:00.000-05:00' \
+	<pre><code>curl -X GET 'https://api.bcda.cms.gov/api/v2/Group/all/$export?_type=Patient&_since=2020-02-13T08:00:00.000-05:00' \
 	-H "Accept: application/fhir+json" \
 	-H "Prefer: respond-async" \
 	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"</code></pre>
@@ -29,7 +29,7 @@ Prefer: respond-async
 <pre><code>429 Too Many Requests</code></pre>
 
 <h4>Response Headers</h4>
-<pre><code>Content-Location: https://api.bcda.cms.gov/api/v1/jobs/42</code></pre>
+<pre><code>Content-Location: https://api.bcda.cms.gov/api/v2/jobs/42</code></pre>
 
 
 <h4>Start a Job using _since within the /Group endpoint Explanation</h4>
@@ -40,7 +40,7 @@ Prefer: respond-async
 		You must provide the groupID of "all" as well as a _since date in the FHIR format. An access token as well as Accept and Prefer headers are required. The dollar sign ($) before the word 	"export" in the URL indicates that the endpoint is	 an action rather than a resource. The format is defined by the FHIR Bulk Data Export spec.
 	</p>
 	<p>
-		If the request was successful, a 202 Accepted response code will be returned and the response will include a Content-Location header. The value of this header indicates the location to check 	for job status and outcome. In the example header 	below, the number 48 in the URL represents the ID of the export job.
+		If the request was successful, a 202 Accepted response code will be returned and the response will include a Content-Location header. The value of this header indicates the location to check 	for job status and outcome. In the example header above, the number 42 in the URL represents the ID of the export job.
 	</p>
 
 	<div class="ds-c-alert ds-c-alert--hide-icon">

--- a/_includes/build/requesting_filtered_data_since_Patient.html
+++ b/_includes/build/requesting_filtered_data_since_Patient.html
@@ -4,7 +4,7 @@
 <h3>Step 2: Start a job</h3>
 
 <h4>Request to start a job using the _since parameter within the /Patient endpoint</h4>
-	<pre><code>GET /api/v1/Patient/$export?_type=Patient&_since=2020-02-13T08:00:00.000-05:00</code></pre>
+	<pre><code>GET /api/v2/Patient/$export?_type=Patient&_since=2020-02-13T08:00:00.000-05:00</code></pre>
 
 <h4>Request Headers</h4>
 <pre><code>Authorization: Bearer <span style="color: #046B99;">{access_token}</span>
@@ -13,7 +13,7 @@ Prefer: respond-async
 </code></pre>
 
 <h4>cURL Command using the _since parameter within the /Patient endpoint</h4>
-	<pre><code>curl -X GET 'https://api.bcda.cms.gov/api/v1/Patient/$export?_type=Patient&_since=2020-02-13T08:00:00.000-05:00' \
+	<pre><code>curl -X GET 'https://api.bcda.cms.gov/api/v2/Patient/$export?_type=Patient&_since=2020-02-13T08:00:00.000-05:00' \
 	-H "Accept: application/fhir+json" \
 	-H "Prefer: respond-async" \
 	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"</code></pre>
@@ -25,7 +25,7 @@ Prefer: respond-async
 <pre><code>429 Too Many Requests</code></pre>
 
 <h4>Response Headers</h4>
-<pre><code>Content-Location: https://api.bcda.cms.gov/api/v1/jobs/42</code></pre>
+<pre><code>Content-Location: https://api.bcda.cms.gov/api/v2/jobs/42</code></pre>
 
 
 <h4>Start a Job using _since within the /Patient endpoint Explanation</h4>
@@ -36,7 +36,7 @@ Prefer: respond-async
 		You must provide a _since date in the FHIR format. An access token as well as Accept and Prefer headers are required. The dollar sign ($) before the word "export" in the URL indicates that the 	endpoint is an action rather than a resource. The format is defined by the FHIR Bulk Data Export spec.
 	</p>
 	<p>
-		If the request was successful, a 202 Accepted response code will be returned and the response will include a Content-Location header. The value of this header indicates the location to check 	for job status and outcome. In the example header below, the number 48 in the URL represents the ID of the export job.
+		If the request was successful, a 202 Accepted response code will be returned and the response will include a Content-Location header. The value of this header indicates the location to check 	for job status and outcome. In the example header above, the number 42 in the URL represents the ID of the export job.
 	</p>
 
 

--- a/_includes/guide/bcda_v2.html
+++ b/_includes/guide/bcda_v2.html
@@ -15,22 +15,22 @@
 <div style="overflow-x:auto;">    
     <table aria-label="Example Curl commands">
         <tr>
-            <th>Sample cURL Command in BCDA V1:</th>
             <th>Sample cURL Command in BCDA V2:</th>
+            <th>Sample cURL Command in BCDA V1:</th>
         </tr>
         <tr>
             <td>
-                <code>curl -X GET 'https://sandbox.bcda.cms.gov/api/v1/Patient/$export' \
+                <code>curl -X GET 'https://sandbox.bcda.cms.gov/api/v2/Group/all/$export' \
                     -H "accept: application/fhir+json" \
                     -H "Prefer: respond-async" \
                     -H "Authorization: Bearer {access_token}"</code>
             </td>
             <td>
-                <code>curl -X GET 'https://sandbox.bcda.cms.gov/api/v2/Patient/$export' \
+                <code>curl -X GET 'https://sandbox.bcda.cms.gov/api/v1/Group/all/$export' \
                     -H "accept: application/fhir+json" \
                     -H "Prefer: respond-async" \
                     -H "Authorization: Bearer {access_token}"</code>
-            </td>    
+            </td>  
         </tr>
     </table>
 </div>    

--- a/_includes/guide/bcda_v2.html
+++ b/_includes/guide/bcda_v2.html
@@ -23,14 +23,14 @@
                 <pre><code>curl -X GET 'https://sandbox.bcda.cms.gov/api/v2/Group/all/$export' \
 -H "accept: application/fhir+json" \
 -H "Prefer: respond-async" \
--H "Authorization: Bearer {access_token}"
+-H "Authorization: Bearer {access_token}" \
 -v</code></pre>
             </td>
             <td>
                 <pre><code>curl -X GET 'https://sandbox.bcda.cms.gov/api/v1/Group/all/$export' \
 -H "accept: application/fhir+json" \
 -H "Prefer: respond-async" \
--H "Authorization: Bearer {access_token}"
+-H "Authorization: Bearer {access_token}" \
 -v</code></pre>
             </td>  
         </tr>

--- a/_includes/guide/bcda_v2.html
+++ b/_includes/guide/bcda_v2.html
@@ -20,16 +20,18 @@
         </tr>
         <tr>
             <td>
-                <code>curl -X GET 'https://sandbox.bcda.cms.gov/api/v2/Group/all/$export' \
-                    -H "accept: application/fhir+json" \
-                    -H "Prefer: respond-async" \
-                    -H "Authorization: Bearer {access_token}"</code>
+                <pre><code>curl -X GET 'https://sandbox.bcda.cms.gov/api/v2/Group/all/$export' \
+-H "accept: application/fhir+json" \
+-H "Prefer: respond-async" \
+-H "Authorization: Bearer {access_token}"
+-v</code></pre>
             </td>
             <td>
-                <code>curl -X GET 'https://sandbox.bcda.cms.gov/api/v1/Group/all/$export' \
-                    -H "accept: application/fhir+json" \
-                    -H "Prefer: respond-async" \
-                    -H "Authorization: Bearer {access_token}"</code>
+                <pre><code>curl -X GET 'https://sandbox.bcda.cms.gov/api/v1/Group/all/$export' \
+-H "accept: application/fhir+json" \
+-H "Prefer: respond-async" \
+-H "Authorization: Bearer {access_token}"
+-v</code></pre>
             </td>  
         </tr>
     </table>

--- a/_includes/guide/try_the_api.html
+++ b/_includes/guide/try_the_api.html
@@ -110,7 +110,7 @@
 	<h3>
 		Sample cURL Command to Start a Job
 	</h3>
-<pre><code>curl -X GET 'https://sandbox.bcda.cms.gov/api/v1/Patient/$export' \
+<pre><code>curl -X GET 'https://sandbox.bcda.cms.gov/api/v2/Group/all/$export' \
 -H "accept: application/fhir+json" \
 -H "Prefer: respond-async" \
 -H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>" \
@@ -125,7 +125,7 @@
 	If the request was successful, we will receive a response with the code 202 containing a few headers. One of the headers (Content-Location) will contain a URL. Notice that the URL ends in a number. This is the Job ID of the job we just started. In the next step, we will use this URL and Job ID to check if the server is done preparing our file(s).
 </p>
 <pre><code>202 Accepted
-Content-Location: https://sandbox.bcda.cms.gov/api/v1/jobs/42
+Content-Location: https://sandbox.bcda.cms.gov/api/v2/jobs/42
 </code></pre>
 
 
@@ -148,7 +148,7 @@ Content-Location: https://sandbox.bcda.cms.gov/api/v1/jobs/42
 <H4>
 	Sample cURL Command to Check the Job Status
 </H4>
-<pre><code>curl -X GET 'https://sandbox.bcda.cms.gov/api/v1/jobs/42' \
+<pre><code>curl -X GET 'https://sandbox.bcda.cms.gov/api/v2/jobs/42' \
 -H "accept: application/fhir+json" \
 -H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"
 </code></pre>
@@ -159,11 +159,11 @@ Content-Location: https://sandbox.bcda.cms.gov/api/v1/jobs/42
 	It looks like our job is finished and our data is ready to be downloaded.
 </p>
 <p>
-	If the request was successful, and the job is finished, we will receive a response containing many headers. Some of these headers ("url") will contain a URL. Each of these URLs corresponds to a file containing claims data. We received three files: one for each resource type. We will use these URLs to download the data in the final step.
+	If the request was successful, and the job is finished, we will receive a response containing many headers. Some of these headers ("url") will contain a URL. Each of these URLs corresponds to a file containing claims data. We received five files: one for each resource type. We will use these URLs to download the data in the final step.
 </p>
 	<pre><code>{
   "transactionTime": "2021-12-09T20:44:01.705398Z",
-  "request": "https://sandbox.bcda.cms.gov/api/v1/Patient/$export",
+  "request": "https://sandbox.bcda.cms.gov/api/v2/Patient/$export",
   "requiresAccessToken": true,
   "output": [
     {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7331

## 🛠 Changes
- update cURL commands to use BCDA V2 and `/Group/all` in our general guidance
- minor updates to content supporting the sample cURL commands
- improved formatting for a few cURL commands
- other small corrections unrelated to cURL commands

## ℹ️ Context for reviewers
Some changes to align with recommended use of the API. Encourage use of BCDA V2 over V1 and the /Group endpoint over the /Patient endpoint. There are some other very minor changes to content to align with the updated code samples, but a more comprehensive review of the guidance is planned in [BCDA-7330](https://jira.cms.gov/browse/BCDA-7330)

## ✅ Acceptance Validation

Executed the new sandbox curl commands locally and inspected static site visually on stage.bcda.cms.gov

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
