### PR TITLE
BCDA-7460: reverting additional resources to ordered list

### DIFF
--- a/_includes/data/additional_resources.html
+++ b/_includes/data/additional_resources.html
@@ -1,4 +1,4 @@
- <ul>
+ <ol>
       <li><a href="https://www.hl7.org/fhir/" target="_blank" rel="noopener" class="in-text__link"> FHIR/HL7 </a></li>
       <li><a href="http://build.fhir.org/ig/HL7/VhDir/bulk-data.html" target="_blank" rel="noopener" class="in-text__link"> Bulk FHIR specification </a></li>
       <li><a href="https://bluebutton.cms.gov/developers/" target="_blank" rel="noopener" class="in-text__link"> Beneficiary FHIR Data Server (BFD)/ Blue Button API </a></li>
@@ -6,4 +6,4 @@
       <li>Intro to the <a href="https://www.json.org/json-en.html" target="_blank" rel="noopener" class="in-text__link">JSON Format</a> and <a href="https://github.com/ndjson/ndjson-spec/" target="_blank" rel="noopener" class="in-text__link">NDJSON</a></li>
       <li><a href="https://jsonlint.com/" target="_blank" rel="noopener" class="in-text__link"> JSON format viewer/validator (raw text/JSON format converter) </a></li>
       <li><a href="http://hl7.org/fhir/STU3/validation.html" target="_blank" rel="noopener" class="in-text__link"> Intro to valid FHIR formats </a></li>
- </ul>
+ </ol>


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7460

## 🛠 Changes

Reverted the "Additional Resources" section to use an ordered list.

## ℹ️ Context for reviewers

- https://github.com/CMSgov/bcda-static-site/pull/186 contains the changes of the ndjson links.

## ✅ Acceptance Validation

ran locally.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
