### PR TITLE
BCDA-7818: Update documentation for 24 hour job archive rule

### DIFF
--- a/_includes/build/requesting_data_all_three.html
+++ b/_includes/build/requesting_data_all_three.html
@@ -164,7 +164,7 @@ Accept-Encoding: gzip</code></pre>
     	<div class="ds-c-alert__body">
     	  <h3 class="ds-c-alert__heading"> Files expire after 24 hours.</h3>
     	    <p class="ds-c-alert__text">
-				You will need to download the data file within 24 hours of starting the request to a specific endpoint. Otherwise, the files will expire and you will need to restart the job.
+				You will have 24 hours after the job completes to download the data file(s). Otherwise, the files will expire and you will need to restart the job.
 			</p>
     	</div>
 	</div>


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7818

## 🛠 Changes

- update to the text under `Files expire after 24 hours.`, per the ticket description.

## ℹ️ Context for reviewers
Clearer language.

## ✅ Acceptance Validation

Ran locally and verified output. Also verified in [stage](https://stage.bcda.cms.gov/build.html).

**Current Text:** 
![image](https://github.com/CMSgov/bcda-static-site/assets/126501259/50e0249b-647b-4793-89df-4a2bec778229)

**New Text (PR changes):**
![image](https://github.com/CMSgov/bcda-static-site/assets/126501259/103c6d5a-1ae9-4038-8e3c-cd40edc0d9a3)

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
