### PR TITLE
BCDA-7992: Remove announcement of Google Group

### DIFF
--- a/_includes/updates/links.html
+++ b/_includes/updates/links.html
@@ -72,10 +72,6 @@
         BCDA Shifting to ACO-MS system for API credential management</a> (October 5, 2020)
       </li>
       <li>
-        <a href="https://groups.google.com/g/bc-api/c/15d_dYVXyXQ" target="blank" class="in-text__link">
-        Announcing BCDA's OpenAPI Client Code Generator!</a> (September 10, 2020)
-      </li>
-      <li>
         <a href="https://groups.google.com/g/bc-api/c/P_owdL2oMbA" target="blank" class="in-text__link">
         BCDA Update: `/Group` endpoint released to production</a> (August 6, 2020)
       </li>


### PR DESCRIPTION
Removes misleading Google Group announcement.

## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7992

## 🛠 Changes

Removed HTML block with the announcement.

## ℹ️ Context for reviewers

N/A

## ✅ Acceptance Validation

<img width="882" alt="Screenshot 2024-04-18 at 3 54 40 PM" src="https://github.com/CMSgov/bcda-static-site/assets/162146803/a80d0f19-eba2-4b2f-95f0-0dcac7936808">

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
