### PR TITLE
BCDA-8113: Escape export operator and fix credential rendering

### DIFF
--- a/_includes/build/bcda_v2.html
+++ b/_includes/build/bcda_v2.html
@@ -20,14 +20,14 @@
             </tr>
             <tr>
                 <td>
-                    <pre><code>curl -X GET "https://api.bcda.cms.gov/api/v2/Group/all/$export" \
+                    <pre><code>curl -X GET "https://api.bcda.cms.gov/api/v2/Group/all/\$export" \
 -H "accept: application/fhir+json" \
 -H "Prefer: respond-async" \
 -H "Authorization: Bearer {access_token}" \
 -v</code></pre>
                 </td>
                 <td>
-                    <pre><code>curl -X GET "https://api.bcda.cms.gov/api/v1/Group/all/$export" \
+                    <pre><code>curl -X GET "https://api.bcda.cms.gov/api/v1/Group/all/\$export" \
 -H "accept: application/fhir+json" \
 -H "Prefer: respond-async" \
 -H "Authorization: Bearer {access_token}" \

--- a/_includes/build/requesting_data_all_three.html
+++ b/_includes/build/requesting_data_all_three.html
@@ -29,19 +29,19 @@ Prefer: respond-async
 <h4>cURL Commands to start a job</h4>
 <ol>
 	<li>
-		<pre><code>curl -X GET "https://api.bcda.cms.gov/api/v2/Group/all/$export" \
+		<pre><code>curl -X GET "https://api.bcda.cms.gov/api/v2/Group/all/\$export" \
 	-H "accept: application/fhir+json" \
 	-H "Prefer: respond-async" \
 	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"</code></pre>
 	</li>
 	<li>
-		<pre><code>curl -X GET "https://api.bcda.cms.gov/api/v2/Group/all/$export?_type=ExplanationOfBenefit,Patient" \
+		<pre><code>curl -X GET "https://api.bcda.cms.gov/api/v2/Group/all/\$export?_type=ExplanationOfBenefit,Patient" \
 	-H "accept: application/fhir+json" \
 	-H "Prefer: respond-async" \
 	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"</code></pre>
 	</li>
 	<li>
-		<pre><code>curl -X GET "https://api.bcda.cms.gov/api/v2/Group/all/$export?_type=Patient" \
+		<pre><code>curl -X GET "https://api.bcda.cms.gov/api/v2/Group/all/\$export?_type=Patient" \
 	-H "accept: application/fhir+json" \
 	-H "Prefer: respond-async" \
 	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"</code></pre>

--- a/_includes/build/requesting_data_runouts.html
+++ b/_includes/build/requesting_data_runouts.html
@@ -20,19 +20,19 @@ Prefer: respond-async
 <h4>cURL Commands to start a job</h4>
 <ol>
 	<li>
-		<pre><code>curl -X GET "https://api.bcda.cms.gov/api/v2/Group/runout/$export" \
+		<pre><code>curl -X GET "https://api.bcda.cms.gov/api/v2/Group/runout/\$export" \
 	-H "accept: application/fhir+json" \
 	-H "Prefer: respond-async" \
 	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"</code></pre>
 	</li>
 	<li>
-		<pre><code>curl -X GET "https://api.bcda.cms.gov/api/v2/Group/runout/$export?_type=ExplanationOfBenefit,Patient" \
+		<pre><code>curl -X GET "https://api.bcda.cms.gov/api/v2/Group/runout/\$export?_type=ExplanationOfBenefit,Patient" \
 	-H "accept: application/fhir+json" \
 	-H "Prefer: respond-async" \
 	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"</code></pre>
 	</li>
 	<li>
-		<pre><code>curl -X GET "https://api.bcda.cms.gov/api/v2/Group/runout/$export?_type=Patient" \
+		<pre><code>curl -X GET "https://api.bcda.cms.gov/api/v2/Group/runout/\$export?_type=Patient" \
 	-H "accept: application/fhir+json" \
 	-H "Prefer: respond-async" \
 	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"</code></pre>

--- a/_includes/build/requesting_filtered_data_since_Group.html
+++ b/_includes/build/requesting_filtered_data_since_Group.html
@@ -17,7 +17,7 @@ Prefer: respond-async
 </code></pre>
 
 <h4>cURL Command using the _since parameter within the /Group endpoint</h4>
-	<pre><code>curl -X GET "https://api.bcda.cms.gov/api/v2/Group/all/$export?_type=Patient&_since=2020-02-13T08:00:00.000-05:00" \
+	<pre><code>curl -X GET "https://api.bcda.cms.gov/api/v2/Group/all/\$export?_type=Patient&_since=2020-02-13T08:00:00.000-05:00" \
 	-H "Accept: application/fhir+json" \
 	-H "Prefer: respond-async" \
 	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"</code></pre>

--- a/_includes/build/requesting_filtered_data_since_Patient.html
+++ b/_includes/build/requesting_filtered_data_since_Patient.html
@@ -13,7 +13,7 @@ Prefer: respond-async
 </code></pre>
 
 <h4>cURL Command using the _since parameter within the /Patient endpoint</h4>
-	<pre><code>curl -X GET "https://api.bcda.cms.gov/api/v2/Patient/$export?_type=Patient&_since=2020-02-13T08:00:00.000-05:00" \
+	<pre><code>curl -X GET "https://api.bcda.cms.gov/api/v2/Patient/\$export?_type=Patient&_since=2020-02-13T08:00:00.000-05:00" \
 	-H "Accept: application/fhir+json" \
 	-H "Prefer: respond-async" \
 	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"</code></pre>

--- a/_includes/guide/bcda_v2.html
+++ b/_includes/guide/bcda_v2.html
@@ -20,14 +20,14 @@
         </tr>
         <tr>
             <td>
-                <pre><code>curl -X GET "https://sandbox.bcda.cms.gov/api/v2/Group/all/$export" \
+                <pre><code>curl -X GET "https://sandbox.bcda.cms.gov/api/v2/Group/all/\$export" \
 -H "accept: application/fhir+json" \
 -H "Prefer: respond-async" \
 -H "Authorization: Bearer {access_token}" \
 -v</code></pre>
             </td>
             <td>
-                <pre><code>curl -X GET "https://sandbox.bcda.cms.gov/api/v1/Group/all/$export" \
+                <pre><code>curl -X GET "https://sandbox.bcda.cms.gov/api/v1/Group/all/\$export" \
 -H "accept: application/fhir+json" \
 -H "Prefer: respond-async" \
 -H "Authorization: Bearer {access_token}" \

--- a/_includes/guide/try_the_api.html
+++ b/_includes/guide/try_the_api.html
@@ -11,7 +11,7 @@
 	All requests for BCDA data follow this four step process, as do other APIs following the Bulk FHIR specifications.
 </p>
 <p>
-	For more detail for each of these steps and specific information for retrieving production data, see the <a href=/build.html target="_self" class="in-text__link"> Building Your Application</a> page. For this short demo, follow along in your Terminal window or through an application such as Postman. Powershell users will need to replace backslash characters \ with backticks ` to properly escape the $export operation.
+	For more detail for each of these steps and specific information for retrieving production data, see the <a href=/build.html target="_self" class="in-text__link"> Building Your Application</a> page. For this short demo, follow along in your Terminal window or through an application such as Postman. PowerShell users will need to replace backslash characters \ with backticks ` to properly escape the $export operation.
 </p>
 
 <h2>

--- a/_includes/guide/try_the_api.html
+++ b/_includes/guide/try_the_api.html
@@ -110,7 +110,7 @@
 	<h3>
 		Sample cURL Command to Start a Job
 	</h3>
-<pre><code>curl -X GET "https://sandbox.bcda.cms.gov/api/v2/Group/all/$export" \
+<pre><code>curl -X GET "https://sandbox.bcda.cms.gov/api/v2/Group/all/\$export" \
 -H "accept: application/fhir+json" \
 -H "Prefer: respond-async" \
 -H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>" \

--- a/_includes/guide/try_the_api.html
+++ b/_includes/guide/try_the_api.html
@@ -74,7 +74,7 @@
 	Sample cURL Command to Submit Credentials for an Access Token
 </h3>
 <pre><code>curl -d "" -X POST "https://sandbox.bcda.cms.gov/auth/token" \
-	--user {{site.data.credentials.extra_small.client_id}}:{{site.data.credentials.extra_small.client_secret}} \
+	--user {{site.data.credentials.sandbox.extra_small.client_id}}:{{site.data.credentials.sandbox.extra_small.client_secret}} \
 	-H "accept: application/json"</code></pre>
 
 <h3>

--- a/_includes/guide/try_the_api.html
+++ b/_includes/guide/try_the_api.html
@@ -11,7 +11,7 @@
 	All requests for BCDA data follow this four step process, as do other APIs following the Bulk FHIR specifications.
 </p>
 <p>
-	For more detail for each of these steps and specific information for retrieving production data, see the <a href=/build.html target="_self" class="in-text__link"> Building Your Application</a> page. For this short demo, follow along in your Terminal window or through an application such as Postman.
+	For more detail for each of these steps and specific information for retrieving production data, see the <a href=/build.html target="_self" class="in-text__link"> Building Your Application</a> page. For this short demo, follow along in your Terminal window or through an application such as Postman. Powershell users will need to replace backslash characters \ with backticks ` to properly escape the $export operation.
 </p>
 
 <h2>

--- a/_includes/partial/faq.html
+++ b/_includes/partial/faq.html
@@ -58,7 +58,7 @@
   </div>
   <p>Access to the Claim and ClaimResponse resources is handled within BCDA on a per ACO (Accountable Care Organization) ID level. There are no required changes to credentials for those REACH ACOs who would like access to the V2 endpoint. The BCDA V2 service supports the same functionality as V1 API endpoints in both the sandbox and production API environments. All V2 endpoints should work as described in the existing BCDA documentation. To transition from V1 to your BCDA V2 endpoints, replace ‘v1’ in the API call URLs with ‘v2’, as in the cURL example below:
   </p>
-<pre><code>curl -X GET "https://sandbox.bcda.cms.gov/api/v1/Patient/$export" \
+<pre><code>curl -X GET "https://sandbox.bcda.cms.gov/api/v1/Patient/\$export" \
 -H "accept: application/fhir+json" \
 -H "Prefer: respond-async" \
 -H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>" \


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8113

## 🛠 Changes

Ensure "Try the API" credentials show properly
Escape export operator to ensure that all environments can utilize the CURL commands. 

## ℹ️ Context for reviewers

When we fixed the curl commands for windows cmd, we broke it for powershell. Now, everyone can live in harmony. 

## ✅ Acceptance Validation

![image](https://github.com/CMSgov/bcda-static-site/assets/120701369/fb307456-3a5d-422b-b0d4-71a4416d41f7)


## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
