### PR TITLE
BCDA-8272: Update link to the Bulk FHIR specification on the website

### DIFF
--- a/_includes/data/additional_resources.html
+++ b/_includes/data/additional_resources.html
@@ -1,6 +1,6 @@
  <ol>
       <li><a href="https://www.hl7.org/fhir/" target="_blank" rel="noopener" class="in-text__link"> FHIR/HL7 </a></li>
-      <li><a href="http://build.fhir.org/ig/HL7/VhDir/bulk-data.html" target="_blank" rel="noopener" class="in-text__link"> Bulk FHIR specification </a></li>
+      <li><a href="http://hl7.org/fhir/uv/bulkdata/" target="_blank" rel="noopener" class="in-text__link"> Bulk FHIR specification </a></li>
       <li><a href="https://bluebutton.cms.gov/developers/" target="_blank" rel="noopener" class="in-text__link"> Beneficiary FHIR Data Server (BFD)/ Blue Button API </a></li>
       <li><a href="https://bluebutton.cms.gov/assets/ig/index.html" target="_blank" rel="noopener" class="in-text__link"> Beneficiary FHIR Data Server (BFD)/ Blue Button Implementation Guide </a></li>
       <li>Intro to the <a href="https://www.json.org/json-en.html" target="_blank" rel="noopener" class="in-text__link">JSON Format</a> and <a href="https://github.com/ndjson/ndjson-spec/" target="_blank" rel="noopener" class="in-text__link">NDJSON</a></li>

--- a/common/data_guide.md
+++ b/common/data_guide.md
@@ -67,7 +67,7 @@ In order to aid in users’ understanding of BCDA file data and structure, we pr
 To learn more about FHIR, bulk FHIR specifications, or the  Beneficiary FHIR Data Server (BFD) API, please visit these resources:
 
 * [FHIR/HL7](https://www.hl7.org/fhir/){:target="_blank"}
-* [Bulk FHIR specification](http://build.fhir.org/ig/HL7/VhDir/bulk-data.html){:target="_blank"}
+* [Bulk FHIR specification](http://hl7.org/fhir/uv/bulkdata/){:target="_blank"}
 * [Beneficiary FHIR Data Server (BFD)/ Blue Button API](https://bluebutton.cms.gov/developers/){:target="_blank"}
 * [Beneficiary FHIR Data Server (BFD)/ Blue Button Implementation Guide](https://bluebutton.cms.gov/assets/ig/index.html){:target="_blank"}
 * Intro to the [JSON Format](http://json.org){:target="_blank"} and [NDJSON](https://github.com/ndjson/ndjson-spec/){:target="_blank"}


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8272

## 🛠 Changes

Bulk FHIR IG link has been updated. 

## ℹ️ Context

The link to the Bulk FHIR specification points to an old IG that hasn't been updated in a long time and should not be referenced as an approved standard.

Go to [Additional Resources ](https://bcda.cms.gov/data.html#additional-resources)(2nd item in the list) - link takes the user to https://build.fhir.org/ig/HL7/VhDir/bulk-data.html 

Expected: link should take the user to https://hl7.org/fhir/uv/bulkdata/
<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Ran locally and verified link works correctly.
