### PR TITLE
Update partially adjudicated claims data sets - enrollee count

### DIFF
--- a/_includes/guide/bcda_enhancement_credentials.html
+++ b/_includes/guide/bcda_enhancement_credentials.html
@@ -5,14 +5,14 @@
     {{site.data.credentials.enhancement.small.client_id}}
     {%- endcapture -%}
 
-    {% include copy_snippet.md code=client_id aco='Small REACH ACO (100 synthetic beneficiaries)' type='Client ID' %}
+    {% include copy_snippet.md code=client_id aco='Small REACH ACO (110 synthetic beneficiaries)' type='Client ID' %}
 
     Client Secret:
     {%- capture client_secret -%}
     {{site.data.credentials.enhancement.small.client_secret}}
     {%- endcapture -%}
 
-    {% include copy_snippet.md code=client_secret aco='Small REACH ACO (100 synthetic beneficiaries)' type='Client Secret' %}
+    {% include copy_snippet.md code=client_secret aco='Small REACH ACO (110 synthetic beneficiaries)' type='Client Secret' %}
 </div>
 
 <p><button class="accordion" type="button" aria-expanded="false" onclick='metricTagging("BCDA", "Try the API: Accordion", "Large REACH ACO (11,000 synthetic beneficiaries)")'> Large REACH ACO (11,000 Synthetic Beneficiaries) </button></p>
@@ -22,12 +22,12 @@
     {{site.data.credentials.enhancement.large.client_id}}
     {%- endcapture -%}
 
-    {% include copy_snippet.md code=client_id aco='Large DCE (10,000 synthetic beneficiaries)' type='Client ID' %}
+    {% include copy_snippet.md code=client_id aco='Large DCE (11,000 synthetic beneficiaries)' type='Client ID' %}
 
     Client Secret:
     {%- capture client_secret -%}
     {{site.data.credentials.enhancement.large.client_secret}}
     {%- endcapture -%}
 
-    {% include copy_snippet.md code=client_secret aco='Large DCE (10,000 synthetic beneficiaries)' type='Client Secret' %}
+    {% include copy_snippet.md code=client_secret aco='Large DCE (11,000 synthetic beneficiaries)' type='Client Secret' %}
 </div>

--- a/_includes/guide/bcda_enhancement_credentials.html
+++ b/_includes/guide/bcda_enhancement_credentials.html
@@ -1,4 +1,4 @@
-<p><button class="accordion" type="button" aria-expanded="false" onclick='metricTagging("BCDA", "Try the API: Accordion", "Small REACH ACO (100 synthetic beneficiaries)")'> Small REACH ACO (100 synthetic beneficiaries) </button></p>
+<p><button class="accordion" type="button" aria-expanded="false" onclick='metricTagging("BCDA", "Try the API: Accordion", "Small REACH ACO (110 synthetic beneficiaries)")'> Small REACH ACO (110 synthetic beneficiaries) </button></p>
 <div class="acc_content">
     Client ID:
     {%- capture client_id -%}
@@ -15,7 +15,7 @@
     {% include copy_snippet.md code=client_secret aco='Small REACH ACO (100 synthetic beneficiaries)' type='Client Secret' %}
 </div>
 
-<p><button class="accordion" type="button" aria-expanded="false" onclick='metricTagging("BCDA", "Try the API: Accordion", "Large REACH ACO (10,000 synthetic beneficiaries)")'> Large REACH ACO (10,000 Synthetic Beneficiaries) </button></p>
+<p><button class="accordion" type="button" aria-expanded="false" onclick='metricTagging("BCDA", "Try the API: Accordion", "Large REACH ACO (11,000 synthetic beneficiaries)")'> Large REACH ACO (11,000 Synthetic Beneficiaries) </button></p>
 <div class="acc_content">
     Client ID:
     {%- capture client_id -%}


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8288

## 🛠 Changes

Small REACH ACO - 100 → 110
Large REACH ACO - 10,000 → 11,000

## ℹ️ Context

Website needs to accurately reflect the number of enrollees in the synthetic data sets after the changes in [BCDA-8125](https://jira.cms.gov/browse/BCDA-8125).

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
