### PR TITLE
BCDA-8251 Update all curl examples for /Patient and /Group endpoints …

### DIFF
--- a/_includes/build/bcda_v2.html
+++ b/_includes/build/bcda_v2.html
@@ -24,14 +24,14 @@
 -H "accept: application/fhir+json" \
 -H "Prefer: respond-async" \
 -H "Authorization: Bearer {access_token}" \
--v</code></pre>
+-i</code></pre>
                 </td>
                 <td>
                     <pre><code>curl -X GET "https://api.bcda.cms.gov/api/v1/Group/all/\$export" \
 -H "accept: application/fhir+json" \
 -H "Prefer: respond-async" \
 -H "Authorization: Bearer {access_token}" \
--v</code></pre>
+-i</code></pre>
                 </td>  
             </tr>
         </table>

--- a/_includes/build/requesting_data_all_three.html
+++ b/_includes/build/requesting_data_all_three.html
@@ -32,19 +32,22 @@ Prefer: respond-async
 		<pre><code>curl -X GET "https://api.bcda.cms.gov/api/v2/Group/all/\$export" \
 	-H "accept: application/fhir+json" \
 	-H "Prefer: respond-async" \
-	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"</code></pre>
+	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>" \
+	-i</code></pre>
 	</li>
 	<li>
 		<pre><code>curl -X GET "https://api.bcda.cms.gov/api/v2/Group/all/\$export?_type=ExplanationOfBenefit,Patient" \
 	-H "accept: application/fhir+json" \
 	-H "Prefer: respond-async" \
-	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"</code></pre>
+	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>" \
+	-i</code></pre>
 	</li>
 	<li>
 		<pre><code>curl -X GET "https://api.bcda.cms.gov/api/v2/Group/all/\$export?_type=Patient" \
 	-H "accept: application/fhir+json" \
 	-H "Prefer: respond-async" \
-	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"</code></pre>
+	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>" \
+	-i</code></pre>
 	</li>
 </ol>
 
@@ -93,8 +96,8 @@ Accept: application/fhir+json</code></pre>
 
 <h4>cURL Command to check the job status</h4>
 	<pre><code>curl -X GET "https://api.bcda.cms.gov/api/v2/jobs/42" \
-	-H "accept: application/fhir+json" \
-	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"</code></pre>
+-H "accept: application/fhir+json" \
+-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"</code></pre>
 
 <h4>Response Example: Completed Job</h4>
 	<pre><code>{

--- a/_includes/build/requesting_data_all_three.html
+++ b/_includes/build/requesting_data_all_three.html
@@ -96,8 +96,8 @@ Accept: application/fhir+json</code></pre>
 
 <h4>cURL Command to check the job status</h4>
 	<pre><code>curl -X GET "https://api.bcda.cms.gov/api/v2/jobs/42" \
--H "accept: application/fhir+json" \
--H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"</code></pre>
+	-H "accept: application/fhir+json" \
+	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"</code></pre>
 
 <h4>Response Example: Completed Job</h4>
 	<pre><code>{

--- a/_includes/build/requesting_data_runouts.html
+++ b/_includes/build/requesting_data_runouts.html
@@ -23,19 +23,22 @@ Prefer: respond-async
 		<pre><code>curl -X GET "https://api.bcda.cms.gov/api/v2/Group/runout/\$export" \
 	-H "accept: application/fhir+json" \
 	-H "Prefer: respond-async" \
-	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"</code></pre>
+	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>" \
+	-i</code></pre>
 	</li>
 	<li>
 		<pre><code>curl -X GET "https://api.bcda.cms.gov/api/v2/Group/runout/\$export?_type=ExplanationOfBenefit,Patient" \
 	-H "accept: application/fhir+json" \
 	-H "Prefer: respond-async" \
-	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"</code></pre>
+	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>" \
+	-i</code></pre>
 	</li>
 	<li>
 		<pre><code>curl -X GET "https://api.bcda.cms.gov/api/v2/Group/runout/\$export?_type=Patient" \
 	-H "accept: application/fhir+json" \
 	-H "Prefer: respond-async" \
-	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"</code></pre>
+	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>" \
+	-i</code></pre>
 	</li>
 </ol>
 

--- a/_includes/build/requesting_filtered_data_since_Group.html
+++ b/_includes/build/requesting_filtered_data_since_Group.html
@@ -20,7 +20,8 @@ Prefer: respond-async
 	<pre><code>curl -X GET "https://api.bcda.cms.gov/api/v2/Group/all/\$export?_type=Patient&_since=2020-02-13T08:00:00.000-05:00" \
 	-H "Accept: application/fhir+json" \
 	-H "Prefer: respond-async" \
-	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"</code></pre>
+	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>" \
+	-i</code></pre>
 
 <h4>Response Example: Successful Request</h4>
 <pre><code>202 Accepted</code></pre>

--- a/_includes/build/requesting_filtered_data_since_Patient.html
+++ b/_includes/build/requesting_filtered_data_since_Patient.html
@@ -16,7 +16,8 @@ Prefer: respond-async
 	<pre><code>curl -X GET "https://api.bcda.cms.gov/api/v2/Patient/\$export?_type=Patient&_since=2020-02-13T08:00:00.000-05:00" \
 	-H "Accept: application/fhir+json" \
 	-H "Prefer: respond-async" \
-	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"</code></pre>
+	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>" \
+	-i</code></pre>
 
 <h4>Response Example: Successful Request</h4>
 <pre><code>202 Accepted</code></pre>

--- a/_includes/guide/bcda_v2.html
+++ b/_includes/guide/bcda_v2.html
@@ -24,14 +24,14 @@
 -H "accept: application/fhir+json" \
 -H "Prefer: respond-async" \
 -H "Authorization: Bearer {access_token}" \
--v</code></pre>
+-i</code></pre>
             </td>
             <td>
                 <pre><code>curl -X GET "https://sandbox.bcda.cms.gov/api/v1/Group/all/\$export" \
 -H "accept: application/fhir+json" \
 -H "Prefer: respond-async" \
 -H "Authorization: Bearer {access_token}" \
--v</code></pre>
+-i</code></pre>
             </td>  
         </tr>
     </table>

--- a/_includes/guide/try_the_api.html
+++ b/_includes/guide/try_the_api.html
@@ -105,17 +105,16 @@
 	With our new access token, we are able to make more requests to the API. We will now tell the server to deliver our data.
 </p>
 <p>
-	In this example, we requested data from the /Patient endpoint with no date filter (no _since parameter) and no specified resource type (no _type parameter). We included the long string of characters from the previous step (our access token) in the authorization header (-H "Authorization: Bearer "). Notice that we needed to include the word "Bearer" followed by a space before the access token. We also added "-v" in order to see the Job ID.
+	In this example, we requested data from the /Patient endpoint with no date filter (no _since parameter) and no specified resource type (no _type parameter). We included the long string of characters from the previous step (our access token) in the authorization header (-H "Authorization: Bearer "). Notice that we needed to include the word "Bearer" followed by a space before the access token. We also added "-i" in order to see the Job ID.
 </p>
 	<h3>
 		Sample cURL Command to Start a Job
 	</h3>
 <pre><code>curl -X GET "https://sandbox.bcda.cms.gov/api/v2/Group/all/\$export" \
--H "accept: application/fhir+json" \
--H "Prefer: respond-async" \
--H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>" \
--v
-</code></pre>
+	-H "accept: application/fhir+json" \
+	-H "Prefer: respond-async" \
+	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>" \
+	-i</code></pre>
 
 <h3>Response Example after Starting a Job</h3>
 <p>
@@ -150,8 +149,7 @@ Content-Location: https://sandbox.bcda.cms.gov/api/v2/jobs/42
 </H4>
 <pre><code>curl -X GET "https://sandbox.bcda.cms.gov/api/v2/jobs/42" \
 -H "accept: application/fhir+json" \
--H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"
-</code></pre>
+-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"</code></pre>
 <h4>
 	Response Example after Checking on a Job
 </h4>

--- a/_includes/partial/faq.html
+++ b/_includes/partial/faq.html
@@ -59,11 +59,10 @@
   <p>Access to the Claim and ClaimResponse resources is handled within BCDA on a per ACO (Accountable Care Organization) ID level. There are no required changes to credentials for those REACH ACOs who would like access to the V2 endpoint. The BCDA V2 service supports the same functionality as V1 API endpoints in both the sandbox and production API environments. All V2 endpoints should work as described in the existing BCDA documentation. To transition from V1 to your BCDA V2 endpoints, replace ‘v1’ in the API call URLs with ‘v2’, as in the cURL example below:
   </p>
 <pre><code>curl -X GET "https://sandbox.bcda.cms.gov/api/v1/Patient/\$export" \
--H "accept: application/fhir+json" \
--H "Prefer: respond-async" \
--H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>" \
--v
-</code></pre>
+  -H "accept: application/fhir+json" \
+  -H "Prefer: respond-async" \
+  -H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>" \
+  -i</code></pre>
   <div class="ds-u-font-weight--bold">13) Are partially adjudicated claims received after a supplier’s orders are completed and the claims are submitted for payment? Or, are they received in a pre-authorization form? For example, if we place an order for an x-ray and then the x-ray supplier first submits a pre-op before they even see the patient, would we be receiving any of those before the event actually happens or is partially adjudicated data only available after the fact?
   </div>
   <p>In Medicare Fee-for-Service (FFS), in the timeline of a supplier order and partially adjudicated data, there is no pre-authorization information available. In BCDA, we only see partially adjudicated claims for actual claims, not for the pre-authorization type or a pre-determination type.


### PR DESCRIPTION
…to use -i

## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8251

## 🛠 Changes

Updated all references and curl examples from curls -v param to curls -i param.

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

Curls -v param shows all http request info which can be a lot.  Curls -i param only shows the important info (headers, response).

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->

Went through the site locally finding all references to -v, -i, /Group, and /Patient.
