### PR TITLE
Remove option 1 to request a token using curl

### DIFF
--- a/_includes/build/access_token.html
+++ b/_includes/build/access_token.html
@@ -32,15 +32,9 @@
 <h4>
 	Access Token cURL Command
 </h4>
-	<p>
-		cURL Option 1: This cURL command requires separate Base64 encoding. We have concatenated the Base64 encoding of the ‘Client ID : Secret’ as the argument to the -H flag. Please note that the URL in the Production environment will be different. 
-	</p>
-<pre><code>curl -d "" -X POST "https://sandbox.bcda.cms.gov/auth/token" \
-	-H "accept: application/json" \
-	-H "authorization: Basic MjQ2MmM5NmItNjQyNy00ZWZiLWFlZDctMTE4ZTIwYzJlOTk3OjhlODdmMGViYzUwZDEwZjFiYzk3MzQzMjlhOTkwMDE3OWI4NGNjZDM5ZTRkMDkyMGI5MDVjYzM1OWNmNmU5NGE2ZTc2MGJiZTNhMDg5MGM3"</code></pre>
 
 <p>
-	cURL Option 2: This cURL command encodes your credentials into Base64.
+	This command takes advantage of curl’s built-in ability to Base-64 encode your credentials, request, and receive your token in a single step. The authorization in your request header will be substituted with "--user {client_id}:{client_secret}"
 </p>
 
 <pre><code>curl -d "" -X POST "https://sandbox.bcda.cms.gov/auth/token" \


### PR DESCRIPTION
Address feedback from Karley's review of staging r79

## 🎫 Ticket
https://cmsgov.slack.com/archives/CHG7Q7XNH/p1730998587225749

## 🛠 Changes
Remove option 1 to request a token using curl

## ℹ️ Context
we don't provide a sample command on how to actually encode the credentials, and it's cleaner to just point everyone to the curl command with the --user flag

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Validated in staging
<img width="724" alt="image" src="https://github.com/user-attachments/assets/b977d6f3-f146-4ad3-af82-48ca0d23a96b">
