### PR TITLE
BCDA-8390-adjust-file-download-copy

### DIFF
--- a/_includes/build/best_practices_download_speed.html
+++ b/_includes/build/best_practices_download_speed.html
@@ -4,7 +4,7 @@
   </h3>
 
   <p>
-    Requesting compressed data can help increase your download speed. You can request compressed data files by specifying the `Accept-Encoding: gzip` header in your download requests.
+    Requesting compressed data can help increase your download speed. You can request compressed data files by specifying the `Accept-Encoding: gzip` header in your download requests.  Note that the file downloaded will be a gzip file which you will need to extract into its ndjson format.
   </p>
 
   <H4>
@@ -12,7 +12,8 @@
   </H4>
   <pre><code>curl "<span style="color: #046B99;">{output_url}</span>" \
 	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>" \
-	-H "Accept-Encoding: gzip"
+	-H "Accept-Encoding: gzip" \
+	--output "your-file-name"
 </code></pre>
 
   <h3>

--- a/_includes/build/requesting_data_all_three.html
+++ b/_includes/build/requesting_data_all_three.html
@@ -144,7 +144,8 @@ Accept-Encoding: gzip</code></pre>
 <h4>cURL Command to download the data</h4>
 	<pre><code>curl -X GET "<span style="color: #046B99;">{output_url}</span>" \
 	-H "Accept-Encoding: gzip" \
-	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>"</code></pre>
+	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>" \
+	--output "your-file-name"</code></pre>
 
 <h4>Response Example</h4>
 	<p>
@@ -173,7 +174,7 @@ Accept-Encoding: gzip</code></pre>
 	</div>
 
 	<p>
-		The "Accept-Encoding: gzip" header is optional, but will return a significantly smaller (about 30X smaller) file with a faster download speed. Follow our recommended best practices for <a href="#speeding-up-downloads" class="in-text__link">speeding up downloads</a>.
+		The "Accept-Encoding: gzip" header is optional, but will return a significantly smaller (about 30X smaller) file with a faster download speed. Follow our recommended best practices for <a href="#speeding-up-downloads" class="in-text__link">speeding up downloads</a>.  Note that the file downloaded will be a gzip file which you will need to extract into its ndjson format.
 	</p>
 	<p>
 		The response will be the requested data as FHIR resources in NDJSON format. Each file related to a different resource type will appear separately and labeled as to which resource type it contains. Examples of data from each Resource Type are available in the guide to working with BCDA data.

--- a/_includes/guide/try_the_api.html
+++ b/_includes/guide/try_the_api.html
@@ -203,7 +203,8 @@ Content-Location: https://sandbox.bcda.cms.gov/api/v2/jobs/<span style="color: #
 	</H4>
 <pre><code>curl "<span style="color: #046B99;">{output_url}</span>" \
 	-H "Authorization: Bearer <span style="color: #046B99;">{access_token}</span>" \
-	-H "Accept-Encoding: gzip"
+	-H "Accept-Encoding: gzip" \
+	--output "your-file-name"
 </code></pre>
 <h4>
 Response Example after Downloading the Data


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8390

## 🛠 Changes

Adjusting the file download curl command to specifically download a file as output instead of return bits from the request as well as adjust the copy to acknowledge that the file downloaded is a gzip and will need to be extracted to be used.

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Site build and review locally.
