### PR TITLE
Correct credential expiration in ACO-MS

### DIFF
--- a/_includes/build/bcda_credentials.html
+++ b/_includes/build/bcda_credentials.html
@@ -18,7 +18,7 @@
 
 <h3 id="rotate-credentials">Rotate your credentials</h3>
 <p>Your organization's credentials will expire and deactivate after a set period of time. You can rotate BCDA credentials in the <em>API Credentials</em> page to generate a new, active client ID and secret. </p>
-<p>You'll need to rotate credentials every <strong>90 days</strong> in 4i or every <strong>12 months</strong> in ACO-MS. Once you choose the <em>BCDA Credentials</em> tab, select the rotate icon under the <em>Actions</em> column. </p>
+<p>You'll need to rotate credentials every <strong>90 days</strong> in 4i or ACO-MS. Once you choose the <em>BCDA Credentials</em> tab, select the rotate icon under the <em>Actions</em> column. </p>
 
 <h3 id="revoke-credentials">Revoke your credentials</h3>
 <p>You may need to revoke (deactivate) your organization's credentials if they are leaked or compromised. You can create new credentials as a replacement afterward. </p>


### PR DESCRIPTION
Credentials expire after 90 days regardless of which portal they were created in

## 🎫 Ticket
N/A

## 🛠 Changes
Corrected information on when credentials expire

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
