### PR TITLE
BCDA 8636: Add workflows for tag, deploy, release, and 508 compliance

### DIFF
--- a/.github/workflows/508_compliance_check.yml
+++ b/.github/workflows/508_compliance_check.yml
@@ -1,0 +1,33 @@
+name: 508 Compliance Check
+
+on:
+  schedule:
+    - cron: 17 8 * * 1
+  workflow_dispatch:
+    inputs:
+      target_host:
+        description: Check where?
+        required: true
+        default: 'https://stage.bcda.cms.gov'
+        type: choice
+        options:
+          - 'https://stage.bcda.cms.gov'
+          - 'https://bcda.cms.gov'
+
+jobs:
+  compliance_check:
+    name: Compliance Check
+    runs-on: self-hosted
+    steps:
+      - name: Run Axe Check
+        env:
+          TARGET_BASE_URL: ${{ inputs.target_host }}
+        run: |
+          TARGETS_TO_SCAN="${TARGET_BASE_URL}"
+          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/guide.html"
+          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/build.html"
+          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/data.html"
+          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/updates.html"
+          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/partial.html"
+          docker run --init --rm --cap-add=SYS_ADMIN orenfromberg/axe-puppeteer-ci:1.0.0@sha256:f83527a3ae8ab74088c001abfe44836946ba73f0afbbf460447f8a0c40281e70 ${TARGETS_TO_SCAN}
+          

--- a/.github/workflows/508_compliance_check.yml
+++ b/.github/workflows/508_compliance_check.yml
@@ -1,18 +1,19 @@
 name: 508 Compliance Check
 
 on:
-  schedule:
-    - cron: 17 8 * * 1
-  workflow_dispatch:
-    inputs:
-      target_host:
-        description: Check where?
-        required: true
-        default: 'https://stage.bcda.cms.gov'
-        type: choice
-        options:
-          - 'https://stage.bcda.cms.gov'
-          - 'https://bcda.cms.gov'
+  push:
+  # schedule:
+  #   - cron: 17 8 * * 1
+  # workflow_dispatch:
+  #   inputs:
+  #     target_host:
+  #       description: Check where?
+  #       required: true
+  #       default: 'https://stage.bcda.cms.gov'
+  #       type: choice
+  #       options:
+  #         - 'https://stage.bcda.cms.gov'
+  #         - 'https://bcda.cms.gov'
 
 jobs:
   compliance_check:
@@ -21,7 +22,8 @@ jobs:
     steps:
       - name: Run Axe Check
         env:
-          TARGET_BASE_URL: ${{ inputs.target_host }}
+          # TARGET_BASE_URL: ${{ inputs.target_host }}
+          TARGET_BASE_URL: 'https://stage.bcda.cms.gov'
         run: |
           TARGETS_TO_SCAN="${TARGET_BASE_URL}"
           TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/guide.html"

--- a/.github/workflows/508_compliance_check.yml
+++ b/.github/workflows/508_compliance_check.yml
@@ -1,19 +1,18 @@
 name: 508 Compliance Check
 
 on:
-  push:
-  # schedule:
-  #   - cron: 17 8 * * 1
-  # workflow_dispatch:
-  #   inputs:
-  #     target_host:
-  #       description: Check where?
-  #       required: true
-  #       default: 'https://stage.bcda.cms.gov'
-  #       type: choice
-  #       options:
-  #         - 'https://stage.bcda.cms.gov'
-  #         - 'https://bcda.cms.gov'
+  schedule:
+    - cron: 17 8 * * 1
+  workflow_dispatch:
+    inputs:
+      target_host:
+        description: Check where?
+        required: true
+        default: 'https://stage.bcda.cms.gov'
+        type: choice
+        options:
+          - 'https://stage.bcda.cms.gov'
+          - 'https://bcda.cms.gov'
 
 jobs:
   compliance_check:
@@ -22,8 +21,7 @@ jobs:
     steps:
       - name: Run Axe Check
         env:
-          # TARGET_BASE_URL: ${{ inputs.target_host }}
-          TARGET_BASE_URL: 'https://stage.bcda.cms.gov'
+          TARGET_BASE_URL: ${{ inputs.target_host }}
         run: |
           TARGETS_TO_SCAN="${TARGET_BASE_URL}"
           TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/guide.html"

--- a/.github/workflows/508_compliance_check.yml
+++ b/.github/workflows/508_compliance_check.yml
@@ -26,10 +26,10 @@ jobs:
           TARGET_BASE_URL: 'https://stage.bcda.cms.gov'
         run: |
           TARGETS_TO_SCAN="${TARGET_BASE_URL}"
-          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/guide.html"
-          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/build.html"
-          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/data.html"
-          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/updates.html"
-          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_TEST_ENV}/partial.html"
+          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/guide.html"
+          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/build.html"
+          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/data.html"
+          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/updates.html"
+          TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/partial.html"
           docker run --init --rm --cap-add=SYS_ADMIN orenfromberg/axe-puppeteer-ci:1.0.0@sha256:f83527a3ae8ab74088c001abfe44836946ba73f0afbbf460447f8a0c40281e70 ${TARGETS_TO_SCAN}
           

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,86 @@
+name: 'Deploy Static Site'
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_environment:
+        description: Deploy where?
+        required: false
+        default: 'stage'
+        type: choice
+        options:
+          - stage
+          - prod
+      static_repo_ref:
+        description: Which branch or tag?
+        required: true
+        default: 'main'
+        type: 'string'
+  workflow_call:
+    inputs:
+      target_environment:
+        description: Deploy where?
+        required: false
+        default: 'stage'
+        type: 'string'
+      static_repo_ref:
+        description: Which branch or tag?
+        required: true
+        default: 'main'
+        type: 'string'
+jobs:
+  deploy_static_site:
+    name: Deploy Static Site
+    runs-on: self-hosted
+    env:
+      TARGET_BUCKET: ${{ inputs.target_environment == 'prod' && 'bcda.cms.gov' || 'stage.bcda.cms.gov' }}
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v4
+        with:
+          repository: 'CMSgov/bcda-static-site'
+          ref: ${{ inputs.static_repo_ref }}
+      - name: "Set Version"
+        env:
+          STATIC_REPO_REF: ${{ inputs.static_repo_ref }}
+        run: |
+          echo "version: $STATIC_REPO_REF" >> _version_config.yml
+      - name: "Add dirs"
+        run: mkdir -p _site && mkdir -p .jekyll-cache
+      - name: 'Build Image'
+        run: docker compose -f docker-compose.yml build static_site
+      - name: 'Build Site'
+        env:
+          JEKYLL_ENV: ${{ inputs.target_environment == 'prod' && 'prod' || 'dev' }}
+        run: docker compose -f docker-compose.yml run -e JEKYLL_ENV=$JEKYLL_ENV --rm static_site
+      - name: Set env vars from AWS params
+        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+        with:
+          params: |
+            SONAR_HOST_URL=/sonarqube/url
+            SONAR_TOKEN=/sonarqube/token
+      - name: Run quality gate scan
+        if: ${{ inputs.target_environment == 'stage' }}
+        uses: sonarsource/sonarqube-scan-action@master
+        with:
+          args:
+            -Dsonar.projectKey=bcda-aco-static-site
+            -Dsonar.host.url=https://sonarqube.cloud.cms.gov
+            -Dsonar.sources=.
+            -Dsonar.exclusions=ops/*
+            -Dsonar.branch.name=${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+            -Dsonar.projectVersion=${{ github.ref_name == 'main' && github.sha || 'branch' }}
+            -Dsonar.working.directory=./sonar_workspace
+            -Dsonar.qualitygate.wait=true
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/bcda-${{ inputs.target_environment == 'prod' && 'prod' || 'dev' }}-github-actions
+      - name: "Sync _site"
+        run: aws s3 sync _site/ s3://$TARGET_BUCKET/ --delete
+      - name: Invalidate Cloudfront cache
+        run: |
+          DISTRIBUTION_ID=`aws cloudfront list-distributions --query "DistributionList.Items[].{Id:Id, OriginDomainName: Origins.Items[0].DomainName}[?starts_with(OriginDomainName, '$TARGET_BUCKET')].Id" --output text`
+          aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths '/*'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,8 +63,7 @@ jobs:
             SONAR_HOST_URL=/sonarqube/url
             SONAR_TOKEN=/sonarqube/token
       - name: Run quality gate scan
-        # if: ${{ inputs.target_environment == 'stage' }}
-        if: true
+        if: ${{ inputs.target_environment == 'stage' }}
         uses: sonarsource/sonarqube-scan-action@master
         with:
           args:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,22 +1,21 @@
 name: 'Deploy Static Site'
 
 on:
-  push:
-  # workflow_dispatch:
-  #   inputs:
-  #     target_environment:
-  #       description: Deploy where?
-  #       required: false
-  #       default: 'stage'
-  #       type: choice
-  #       options:
-  #         - stage
-  #         - prod
-  #     static_repo_ref:
-  #       description: Which branch or tag?
-  #       required: true
-  #       default: 'main'
-  #       type: 'string'
+  workflow_dispatch:
+    inputs:
+      target_environment:
+        description: Deploy where?
+        required: false
+        default: 'stage'
+        type: choice
+        options:
+          - stage
+          - prod
+      static_repo_ref:
+        description: Which branch or tag?
+        required: true
+        default: 'main'
+        type: 'string'
   workflow_call:
     inputs:
       target_environment:
@@ -35,19 +34,16 @@ jobs:
     name: Deploy Static Site
     runs-on: self-hosted
     env:
-      # TARGET_BUCKET: ${{ inputs.target_environment == 'prod' && 'bcda.cms.gov' || 'stage.bcda.cms.gov' }}
-      TARGET_BUCKET: 'stage.bcda.cms.gov'
+      TARGET_BUCKET: ${{ inputs.target_environment == 'prod' && 'bcda.cms.gov' || 'stage.bcda.cms.gov' }}
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v4
         with:
           repository: 'CMSgov/bcda-static-site'
-          # ref: ${{ inputs.static_repo_ref }}
-          ref: 'main'
+          ref: ${{ inputs.static_repo_ref }}
       - name: "Set Version"
         env:
-          # STATIC_REPO_REF: ${{ inputs.static_repo_ref }}
-          STATIC_REPO_REF: 'main'
+          STATIC_REPO_REF: ${{ inputs.static_repo_ref }}
         run: |
           echo "version: $STATIC_REPO_REF" >> _version_config.yml
       - name: "Add dirs"
@@ -56,8 +52,7 @@ jobs:
         run: docker build . -f Dockerfiles/Dockerfile.static_site -t static_site
       - name: 'Build Site'
         env:
-          # JEKYLL_ENV: ${{ inputs.target_environment == 'prod' && 'prod' || 'dev' }}
-          JEKYLL_ENV: 'dev'
+          JEKYLL_ENV: ${{ inputs.target_environment == 'prod' && 'prod' || 'dev' }}
         run: docker run -e JEKYLL_ENV=$JEKYLL_ENV -v ./_site:/bcda-site-static/_site -v ./.jekyll-cache:/bcda-site-static/.jekyll-cache --rm static_site
       - name: Set env vars from AWS params
         uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
@@ -82,8 +77,7 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ vars.AWS_REGION }}
-          # role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/bcda-${{ inputs.target_environment == 'prod' && 'prod' || 'dev' }}-github-actions
-          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/bcda-dev-github-actions
+          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/bcda-${{ inputs.target_environment == 'prod' && 'prod' || 'dev' }}-github-actions
       - name: "Sync _site"
         run: aws s3 sync _site/ s3://$TARGET_BUCKET/ --delete
       - name: Invalidate Cloudfront cache

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,21 +1,22 @@
 name: 'Deploy Static Site'
 
 on:
-  workflow_dispatch:
-    inputs:
-      target_environment:
-        description: Deploy where?
-        required: false
-        default: 'stage'
-        type: choice
-        options:
-          - stage
-          - prod
-      static_repo_ref:
-        description: Which branch or tag?
-        required: true
-        default: 'main'
-        type: 'string'
+  push:
+  # workflow_dispatch:
+  #   inputs:
+  #     target_environment:
+  #       description: Deploy where?
+  #       required: false
+  #       default: 'stage'
+  #       type: choice
+  #       options:
+  #         - stage
+  #         - prod
+  #     static_repo_ref:
+  #       description: Which branch or tag?
+  #       required: true
+  #       default: 'main'
+  #       type: 'string'
   workflow_call:
     inputs:
       target_environment:
@@ -28,21 +29,25 @@ on:
         required: true
         default: 'main'
         type: 'string'
+
 jobs:
   deploy_static_site:
     name: Deploy Static Site
     runs-on: self-hosted
     env:
-      TARGET_BUCKET: ${{ inputs.target_environment == 'prod' && 'bcda.cms.gov' || 'stage.bcda.cms.gov' }}
+      # TARGET_BUCKET: ${{ inputs.target_environment == 'prod' && 'bcda.cms.gov' || 'stage.bcda.cms.gov' }}
+      TARGET_BUCKET: 'stage.bcda.cms.gov'
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v4
         with:
           repository: 'CMSgov/bcda-static-site'
-          ref: ${{ inputs.static_repo_ref }}
+          # ref: ${{ inputs.static_repo_ref }}
+          ref: 'main'
       - name: "Set Version"
         env:
-          STATIC_REPO_REF: ${{ inputs.static_repo_ref }}
+          # STATIC_REPO_REF: ${{ inputs.static_repo_ref }}
+          STATIC_REPO_REF: 'main'
         run: |
           echo "version: $STATIC_REPO_REF" >> _version_config.yml
       - name: "Add dirs"
@@ -51,7 +56,8 @@ jobs:
         run: docker compose -f docker-compose.yml build static_site
       - name: 'Build Site'
         env:
-          JEKYLL_ENV: ${{ inputs.target_environment == 'prod' && 'prod' || 'dev' }}
+          # JEKYLL_ENV: ${{ inputs.target_environment == 'prod' && 'prod' || 'dev' }}
+          JEKYLL_ENV: 'dev'
         run: docker compose -f docker-compose.yml run -e JEKYLL_ENV=$JEKYLL_ENV --rm static_site
       - name: Set env vars from AWS params
         uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
@@ -62,7 +68,8 @@ jobs:
             SONAR_HOST_URL=/sonarqube/url
             SONAR_TOKEN=/sonarqube/token
       - name: Run quality gate scan
-        if: ${{ inputs.target_environment == 'stage' }}
+        # if: ${{ inputs.target_environment == 'stage' }}
+        if: true
         uses: sonarsource/sonarqube-scan-action@master
         with:
           args:
@@ -77,7 +84,8 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ vars.AWS_REGION }}
-          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/bcda-${{ inputs.target_environment == 'prod' && 'prod' || 'dev' }}-github-actions
+          # role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/bcda-${{ inputs.target_environment == 'prod' && 'prod' || 'dev' }}-github-actions
+          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/bcda-dev-github-actions
       - name: "Sync _site"
         run: aws s3 sync _site/ s3://$TARGET_BUCKET/ --delete
       - name: Invalidate Cloudfront cache

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,12 +53,12 @@ jobs:
       - name: "Add dirs"
         run: mkdir -p _site && mkdir -p .jekyll-cache
       - name: 'Build Image'
-        run: docker compose -f docker-compose.yml build static_site
+        run: docker build . -f Dockerfiles/Dockerfile.static_site -t static_site
       - name: 'Build Site'
         env:
           # JEKYLL_ENV: ${{ inputs.target_environment == 'prod' && 'prod' || 'dev' }}
           JEKYLL_ENV: 'dev'
-        run: docker compose -f docker-compose.yml run -e JEKYLL_ENV=$JEKYLL_ENV --rm static_site
+        run: docker run -e JEKYLL_ENV=$JEKYLL_ENV -v ./_site:/bcda-site-static/_site -v ./.jekyll-cache:/bcda-site-static/.jekyll-cache --rm static_site
       - name: Set env vars from AWS params
         uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,12 +74,10 @@ jobs:
         with:
           args:
             -Dsonar.projectKey=bcda-aco-static-site
-            -Dsonar.host.url=https://sonarqube.cloud.cms.gov
             -Dsonar.sources=.
-            -Dsonar.exclusions=ops/*
+            -Dsonar.working.directory=./sonar_workspace
             -Dsonar.branch.name=${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
             -Dsonar.projectVersion=${{ github.ref_name == 'main' && github.sha || 'branch' }}
-            -Dsonar.working.directory=./sonar_workspace
             -Dsonar.qualitygate.wait=true
       - uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/tag_and_deploy.yml
+++ b/.github/workflows/tag_and_deploy.yml
@@ -1,28 +1,31 @@
 name: 'Tag and Deploy Static Site'
 
 on:
-  workflow_dispatch:
-    inputs:
-      deploy:
-        description: 'Also deploy to staging?'
-        type: boolean
-        default: true
-        required: true
-      repo_ref:
-        description: 'Which branch or tag?'
-        required: true
-        default: 'main'
-        type: 'string'
+  push:
+  # workflow_dispatch:
+  #   inputs:
+  #     deploy:
+  #       description: 'Also deploy to staging?'
+  #       type: boolean
+  #       default: true
+  #       required: true
+  #     repo_ref:
+  #       description: 'Which branch or tag?'
+  #       required: true
+  #       default: 'main'
+  #       type: 'string'
 
 jobs:
   tag_repo:
     name: Tag Repo
     uses: CMSgov/dpc-app/.github/workflows/tag_release.yml@main
     with:
-      repo_ref: ${{ inputs.repo_ref }}
+      # repo_ref: ${{ inputs.repo_ref }}
+      repo_ref: 'carl/BCDA-8636-add-github-actions-deploy'
     secrets: inherit
   deploy:
-    if: ${{ inputs.deploy }}
+    # if: ${{ inputs.deploy }}
+    if: true
     name: Deploy to Staging
     needs: tag_repo
     uses: ./.github/workflows/deploy.yml

--- a/.github/workflows/tag_and_deploy.yml
+++ b/.github/workflows/tag_and_deploy.yml
@@ -1,0 +1,32 @@
+name: 'Tag and Deploy Static Site'
+
+on:
+  workflow_dispatch:
+    inputs:
+      deploy:
+        description: 'Also deploy to staging?'
+        type: boolean
+        default: true
+        required: true
+      repo_ref:
+        description: 'Which branch or tag?'
+        required: true
+        default: 'main'
+        type: 'string'
+
+jobs:
+  tag_repo:
+    name: Tag Repo
+    uses: CMSgov/dpc-app/.github/workflows/tag_release.yml@main
+    with:
+      repo_ref: ${{ inputs.repo_ref }}
+    secrets: inherit
+  deploy:
+    if: ${{ inputs.deploy }}
+    name: Deploy to Staging
+    needs: tag_repo
+    uses: ./.github/workflows/deploy.yml
+    with:
+      target_environment: staging
+      static_repo_ref: ${{ needs.tag_repo.outputs.tag }}
+    secrets: inherit

--- a/.github/workflows/tag_and_deploy.yml
+++ b/.github/workflows/tag_and_deploy.yml
@@ -1,31 +1,28 @@
 name: 'Tag and Deploy Static Site'
 
 on:
-  push:
-  # workflow_dispatch:
-  #   inputs:
-  #     deploy:
-  #       description: 'Also deploy to staging?'
-  #       type: boolean
-  #       default: true
-  #       required: true
-  #     repo_ref:
-  #       description: 'Which branch or tag?'
-  #       required: true
-  #       default: 'main'
-  #       type: 'string'
+  workflow_dispatch:
+    inputs:
+      deploy:
+        description: 'Also deploy to staging?'
+        type: boolean
+        default: true
+        required: true
+      repo_ref:
+        description: 'Which branch or tag?'
+        required: true
+        default: 'main'
+        type: 'string'
 
 jobs:
   tag_repo:
     name: Tag Repo
     uses: CMSgov/dpc-app/.github/workflows/tag_release.yml@main
     with:
-      # repo_ref: ${{ inputs.repo_ref }}
-      repo_ref: 'carl/BCDA-8636-add-github-actions-deploy'
+      repo_ref: ${{ inputs.repo_ref }}
     secrets: inherit
   deploy:
-    # if: ${{ inputs.deploy }}
-    if: true
+    if: ${{ inputs.deploy }}
     name: Deploy to Staging
     needs: tag_repo
     uses: ./.github/workflows/deploy.yml


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8636 and https://jira.cms.gov/browse/BCDA-8639

## 🛠 Changes

Added tag, deploy, and 508 compliance GHA workflows.

## ℹ️ Context

Moving off of jenkins: https://jira.cms.gov/browse/BCDA-8624

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

I verified these workflows by hardcoding the various inputs to staging and running them `on: push`.
