### PR TITLE
BCDA-8639: Fix cron issue in workflow

### DIFF
--- a/.github/workflows/508_compliance_check.yml
+++ b/.github/workflows/508_compliance_check.yml
@@ -19,9 +19,13 @@ jobs:
     name: Compliance Check
     runs-on: self-hosted
     steps:
+      - name: Set Target Base
+        id: target-base
+        run: |
+          echo "TARGET_BASE_URL=${{ inputs.target_host || 'https://stage.bcda.cms.gov' }}" >> "$GITHUB_OUTPUT"
       - name: Run Axe Check
         env:
-          TARGET_BASE_URL: ${{ inputs.target_host }}
+          TARGET_BASE_URL: ${{ steps.target-base.outputs.TARGET_BASE_URL }}
         run: |
           TARGETS_TO_SCAN="${TARGET_BASE_URL}"
           TARGETS_TO_SCAN="${TARGETS_TO_SCAN} ${TARGET_BASE_URL}/guide.html"


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8639

## 🛠 Changes

Added env var that can be set when a workflow is run from a cron expression.

## ℹ️ Context

Previously the input workflow env var was not accessible during a cron execution.  See failure here: https://github.com/CMSgov/bcda-static-site/actions/runs/12743251972

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
