### PR TITLE
Update deploy workflow so dev bucket doesnt get deleted

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,7 +87,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/bcda-${{ env.JEKYLL_ENV }}-github-actions
       - name: Sync _site with s3
-        run: aws s3 sync _site/ s3://$TARGET_BUCKET/ --delete
+        run: aws s3 sync _site/ s3://$TARGET_BUCKET/ $(["${{ inputs.target_environment }}" == 'prod'] && echo "--delete")
       - name: Invalidate Cloudfront cache
         run: |
           DISTRIBUTION_ID=`aws cloudfront list-distributions --query "DistributionList.Items[].{Id:Id, OriginDomainName: Origins.Items[0].DomainName}[?starts_with(OriginDomainName, '$TARGET_BUCKET')].Id" --output text`


### PR DESCRIPTION
## 🎫 Ticket

n/a

## 🛠 Changes

Updates deploy step so dev S3 bucket doesn't delete directories used by the `uswds-redesign` preview URLs

## ℹ️ Context

Deleting all the contents of dev S3 breaks the redesign preview links by removing the directories that contain the files for those links

## 🧪 Validation

Manual QA