### PR TITLE
[BCDA-9202] Adds backfill content

### DIFF
--- a/_announcements/bcda-performance-improvement-to-speed-up-job-requests.md
+++ b/_announcements/bcda-performance-improvement-to-speed-up-job-requests.md
@@ -1,0 +1,22 @@
+---
+layout: announcement
+page_title: "BCDA performance improvement to speed up job requests"
+description: "We’re excited to announce the launch of a new BCDA.cms.gov based on your feedback, user research, and testing."
+show-side-nav: false
+in-page-nav: true
+published_date: 2024-12-01
+custom_excerpt: "We’re excited to announce the launch of a new BCDA.cms.gov based on your feedback, user research, and testing."
+---
+
+We’ve decreased the time it takes to complete long-running jobs by reducing the number of EOB resources per ndjson file. We’ve also increased the rate limit on API requests by 10X to accommodate the additional files.
+
+What's changing?
+- EOB resources per ndjson file are reduced from 200 to 50. 
+- We’ve increased the rate limit from 300 to 3,000 per 5 minutes from a single IP address.
+
+Why is it changing?
+- The change in EOB file volume decreases the time it takes to complete long-running jobs like requests for historical data.
+- The API rate limit increase lowers likelihood of having your requests throttled.
+
+What can you do to prepare?
+- There’s no action required. It can be helpful to revisit our guidance on [handling 429 errors](https://stage.bcda.cms.gov/build.html#handling-429-error) caused by exceeding the API rate limit.

--- a/_announcements/normal-data-availability-resumed-for-2025-claims.md
+++ b/_announcements/normal-data-availability-resumed-for-2025-claims.md
@@ -1,0 +1,17 @@
+---
+layout: announcement
+page_title: "Normal data availability resumed for 2025 claims"
+description: "We’re excited to announce the launch of a new BCDA.cms.gov based on your feedback, user research, and testing."
+show-side-nav: false
+in-page-nav: true
+published_date: 2025-02-13
+custom_excerpt: "We’re excited to announce the launch of a new BCDA.cms.gov based on your feedback, user research, and testing."
+---
+
+Now that annual maintenance is complete, you’ll have access to all PY 2025 data using the `/Group/all` and `/Patient` endpoints. 
+- **For your first PY 2025 data request** - Use the `all` identifier for any service date.
+- **To request runout data from PY 2024** - Use the `runout` identifier separately with the `/Group` endpoint. This will return data for enrollees who were attributed to your organization in PY 2024, but not PY 2025.
+  - Use the `_since` parameter in conjunction with the `runout` identifier to limit data to updates occurring since your last runout request.
+  - The `runout` identifier will be updated each month up to and including July 2025. After July 2025, new data for enrollees who were attributed to your organization in PY 2024, but not PY 2025, will no longer be included.
+
+Post or send any questions in the <a href="https://groups.google.com/g/bc-api" target="_blank" rel="nofollow noreferrer">Google Group</a> or contact [bcapi@cms.hhs.gov](mailto:bcapi@cms.hhs.gov).

--- a/_announcements/temporary-service-limitation-during-annual-end-of-year-transition.md
+++ b/_announcements/temporary-service-limitation-during-annual-end-of-year-transition.md
@@ -1,0 +1,46 @@
+---
+layout: announcement
+page_title: "Temporary service limitation during annual end-of-year transition"
+description: "We’re excited to announce the launch of a new BCDA.cms.gov based on your feedback, user research, and testing."
+show-side-nav: false
+in-page-nav: true
+published_date: 2024-12-03
+custom_excerpt: "We’re excited to announce the launch of a new BCDA.cms.gov based on your feedback, user research, and testing."
+---
+
+Current or new claims data will be unavailable between January 1, 2025 and <date> due to yearly maintenance. 
+
+This limitation occurs while CMS updates attribution for the new performance year (PY 2025). 
+
+Data will be available again after BCDA receives each organization’s attribution information for PY 2025.
+
+## Temporary data limitations starting 01/2025
+
+- You will only be able to request runout data from BCDA from PY 2024. Use the `runout` identifier with the `/Group` endpoint to return data for enrollees attributed to your organization in PY 2024. 
+  - Claims with a service date in 2025 will be excluded. The claims returned will have a service date no later than December 31, 2024. 
+  - You can use the _since parameter with the runout identifier to limit data to updates occurring since your last runout request.
+  - Review our documentation and example requests for runout data. 
+- You won’t be able to make requests to the `/Group/all` or `/Patient` endpoints. These requests will result in an OperationOutcome error.
+
+Normal functionality will be restored to individual entities as soon as their data is ready. This typically takes 1 month. At that point, you can use the all identifier to request data, including 2025 claims, with the `/Group` and `/Patient` endpoints as usual.
+
+## Example requests and outcomes using BCDA in January 2025
+- A caller makes a request to the /Patient or /Group endpoint using the `all` identifier.
+  - **GET** `/api/v2/Patient/$export`
+  - **GET** `/api/v2/Group/all/$export`
+- The caller receives an OperationOutcome error.
+  - An example OperationOutcome.fhir.json is attached. Callers should use the `/api/v2/Group/runout/$export` endpoint.
+- A caller makes a request to the /Group endpoint using the runout identifier.
+  - **GET** `/api/v2/Group/runout/$export`
+- The caller receives a 202 Accepted response.
+  - Content-Location header sent with the job location:
+    - `Content-Location: /api/v2/jobs/2`
+- A caller polls the /Jobs endpoint until the job completes.
+  - **GET** `/api/v2/jobs/2`
+- The caller can now download the job data.
+  - **GET** `/data/2/output.json`
+  - All claims data will be capped at December 31, 2024.
+
+We’ll post an update here and in the Google Group when the limitation ends for each supported model. Thanks for your patience!
+
+Post or send any questions in the <a href="https://groups.google.com/g/bc-api" target="_blank" rel="nofollow noreferrer">Google Group</a> or contact [bcapi@cms.hhs.gov](mailto:bcapi@cms.hhs.gov).

--- a/_announcements/updated-guidance-on-managing-bcda-credentials.md
+++ b/_announcements/updated-guidance-on-managing-bcda-credentials.md
@@ -1,0 +1,13 @@
+---
+layout: announcement
+page_title: "Normal data availability resumed for 2025 claims"
+description: "We’re excited to announce the launch of a new BCDA.cms.gov based on your feedback, user research, and testing."
+show-side-nav: false
+in-page-nav: true
+published_date: 2024-11-18
+custom_excerpt: "We’re excited to announce the launch of a new BCDA.cms.gov based on your feedback, user research, and testing."
+---
+
+The BCDA team has updated our guidance for model entities managing their BCDA credentials in 4i and ACO-MS. Review manage your BCDA Credentials for model-specific instructions. 
+
+Post or send any questions in the <a href="https://groups.google.com/g/bc-api" target="_blank" rel="nofollow noreferrer">Google Group</a> or contact [bcapi@cms.hhs.gov](mailto:bcapi@cms.hhs.gov).

--- a/_config.yml
+++ b/_config.yml
@@ -70,6 +70,6 @@ collections:
     categories: true
     permalink: /:path:output_ext
   announcements:
-     output: true
+      output: true
   features:
     output: true

--- a/_layouts/announcement.html
+++ b/_layouts/announcement.html
@@ -10,5 +10,6 @@ layout: api-docs
 </a>
 
 <h1 class="margin-top-3">{{ page.page_title }}</h1>
+<p class="margin-top-105 text-base">{{ page.published_date | date_to_string: "ordinal", "US" }}</p>
 
 <div class="usa-prose margin-top-5">{{ content }}</div>

--- a/_pages/announcements.html
+++ b/_pages/announcements.html
@@ -6,17 +6,19 @@ description: "Get updates, release information, and other important news from th
 show-side-nav: false
 ---
 
+{% assign posts = site.announcements | sort: 'published_date' | reverse %}
+
 <h1>{{ page.page_title }}</h1>
 <div class="grid-row">
   <div class="desktop:grid-col-8 grid-col-12">
     <div class="padding-top-4">
-      {% for post in site.announcements %}
+      {% for post in posts %}
       <article class="padding-y-5 border-top position-relative">
         <h2 class="font-sans-lg">
           <a href="{{ post.url | relative_url }}" class="stretched-link text-no-underline" style="color: black;">{{
             post.page_title }}</a>
         </h2>
-        <p class="margin-top-105">{{ post.published_date | date_to_string: "ordinal", "US" }}</p>
+        <p class="margin-top-1 text-base">{{ post.published_date | date_to_string: "ordinal", "US" }}</p>
         <p>{{ post.custom_excerpt }}</p>
         <div class="margin-top-4">
           <div class="usa-button usa-button--outline">


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9202

## 🛠 Changes

Adds backfill announcememt/post content to the new site

## ℹ️ Context

Moves some previous posts from the old site and google group announcements to the new site as a way to start to develop the website as the authoritative source of truth for announcements and to support SEO

## 🧪 Validation

Manual QA
