### PR TITLE
Update deployment paths in workflows

### DIFF
--- a/.github/workflows/a11y-check.yml
+++ b/.github/workflows/a11y-check.yml
@@ -27,7 +27,7 @@ jobs:
           fi
 
       - name: Run pa11y
-        run: npx pa11y-ci --config pa11yci.ci.json --sitemap https://stage.bcda.cms.gov/${{ env.BASE_PATH }}sitemap.xml --sitemap-exclude "/*.pdf" --sitemap-find https://bcda.cms.gov/ --sitemap-replace https://stage.bcda.cms.gov/ --json > pa11y-results.json || echo "EXIT_CODE=$?" >> $GITHUB_ENV
+        run: npx pa11y-ci --config pa11yci.ci.json --sitemap ${{ format('https://stage.bcda.cms.gov/{0}sitemap.xml', env.BASE_PATH) }} --sitemap-exclude "/*.pdf" --sitemap-find https://bcda.cms.gov/ --sitemap-replace https://stage.bcda.cms.gov/ --json > pa11y-results.json || echo "EXIT_CODE=$?" >> $GITHUB_ENV
 
       - name: Save Report to Action Summary
         uses: actions/github-script@v7

--- a/.github/workflows/a11y-check.yml
+++ b/.github/workflows/a11y-check.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Set Deployment Path
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "DEPLOY_PATH=${{ github.event.number }}" >> $GITHUB_ENV
+            echo "BASE_PATH=feature/${{ github.event.number }}/' " >> $GITHUB_ENV
           else
-            echo "DEPLOY_PATH=${{ github.ref_name }}" >> $GITHUB_ENV
+            echo "BASE_PATH='' " >> $GITHUB_ENV
           fi
 
       - name: Run pa11y
-        run: npx pa11y-ci --config pa11yci.ci.json --sitemap https://stage.bcda.cms.gov/${{ env.DEPLOY_PATH }}/sitemap.xml --sitemap-exclude "/*.pdf" --sitemap-find https://bcda.cms.gov/ --sitemap-replace https://stage.bcda.cms.gov/ --json > pa11y-results.json || echo "EXIT_CODE=$?" >> $GITHUB_ENV
+        run: npx pa11y-ci --config pa11yci.ci.json --sitemap https://stage.bcda.cms.gov/${{ env.BASE_PATH }}sitemap.xml --sitemap-exclude "/*.pdf" --sitemap-find https://bcda.cms.gov/ --sitemap-replace https://stage.bcda.cms.gov/ --json > pa11y-results.json || echo "EXIT_CODE=$?" >> $GITHUB_ENV
 
       - name: Save Report to Action Summary
         uses: actions/github-script@v7
@@ -58,6 +58,6 @@ jobs:
       #     payload: |
       #       channel: "C03S23MJFJS"
       #       attachments:
-      #         - text: "Pa11y Results (/${{env.DEPLOY_PATH}}): <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Pa11y Action Summary>"
+      #         - text: "Pa11y Results (/${{env.BASE_PATH}}): <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Pa11y Action Summary>"
       #           mrkdown_in:
       #             - text

--- a/.github/workflows/a11y-check.yml
+++ b/.github/workflows/a11y-check.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set Deployment Path
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "BASE_PATH=feature/${{ github.event.number }}/' " >> $GITHUB_ENV
+            echo "BASE_PATH=feature/${{ github.event.number }}/ " >> $GITHUB_ENV
           else
             echo "BASE_PATH='' " >> $GITHUB_ENV
           fi

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -4,11 +4,30 @@ on:
   schedule:
   - cron: 0 0 * * 0 # every Sunday at midnight
   workflow_dispatch:
-  workflow_call:
-     inputs:
-      deploy_path:
+    inputs:
+      env:
+        description: "The environment to test: staging or prod"
+        required: true
+        type: choice
+        options:
+          - staging
+          - prod
+      feature_path:
+        description: "Feature path to test (e.g. 123 -> feature/123/); if omitted, tests base url"
         required: false
         type: string
+  workflow_call:
+     inputs:
+      env:
+        description: "The environment to test: staging or prod"
+        required: true
+        type: string
+      feature_path:
+        description: "Feature path to test (e.g. 123 -> feature/123/); if omitted, tests base url"
+        required: false
+        type: string
+env:
+  BASE_PATH: ${{ inputs.feature_path && format('feature/{0}/', inputs.feature_path) || '' }}
 
 jobs:
   broken-link-check:
@@ -19,28 +38,28 @@ jobs:
 
     steps:
       - name: Configure AWS Credentials
-        if: ${{ inputs.deploy_path == '' }}
+        if: ${{ inputs.env == 'prod' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.PROD_AWS_ACCOUNT_ID }}:role/delegatedadmin/developer/bcda-prod-github-actions
 
       - name: Fetch Production AWS Parameters
-        if: ${{ inputs.deploy_path == '' }}
+        if: ${{ inputs.env == 'prod' }}
         uses: cmsgov/cdap/actions/aws-params-env-action@main
         with:
           params: |
             TARGET_BUCKET=/bcda/prod/static_site
 
       - name: Configure AWS Credentials
-        if: ${{ inputs.deploy_path != '' }}
+        if: ${{ inputs.env != 'prod' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.STAGE_AWS_ACCOUNT_ID }}:role/delegatedadmin/developer/bcda-dev-github-actions
 
       - name: Fetch Production AWS Parameters
-        if: ${{ inputs.deploy_path != '' }}
+        if: ${{ inputs.env != 'prod' }}
         uses: cmsgov/cdap/actions/aws-params-env-action@main
         with:
           params: |
@@ -48,7 +67,7 @@ jobs:
 
       - name: Download Dev Bucket
         run: |
-          aws s3 sync s3://${TARGET_BUCKET}/${{ inputs.deploy_path && format('/{0}', inputs.deploy_path) || ''}} .
+          aws s3 sync s3://${TARGET_BUCKET}/${{ env.BASE_PATH }} .
 
       - name: "Check for broken links"
         uses: lycheeverse/lychee-action@v2

--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -15,7 +15,7 @@ jobs:
             const commentIdentifier = '## Deploy Preview';
             const commitSha = context.payload.pull_request.head.sha;
             const commitUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${commitSha}`;
-            const previewUrl = `https://stage.bcda.cms.gov/${context.issue.number}/index.html`
+            const previewUrl = `https://stage.bcda.cms.gov/feature/${context.issue.number}/index.html`
 
             const body = `${commentIdentifier}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,8 +37,9 @@ jobs:
           node-version-file: '.nvmrc'
           # node-version: 20 ## Using a .nvmrc file to stay in sync with the repo
      
-      - name: Install jekyll and bundler
+      - name: Install ruby, jekyll, and bundler
         run: |
+          rbenv install
           gem install bundler
           bundle install
   

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,15 +3,19 @@ name: "deploy"
 on:
   workflow_dispatch:
     inputs:
-      deploy_path:
-        description: "S3 directory deployment location"
-        default: "main"
-  workflow_call:
-    inputs:
-      deploy_path:
-        default: "main"
+      feature_path:
+        description: "Feature path to deploy (e.g. 123 -> feature/123/); if omitted, deploys to base url"
         required: false
         type: string
+  workflow_call:
+    inputs:
+      feature_path:
+        description: "Feature path to deploy (e.g. 123 -> feature/123/); if omitted, deploys to base url"
+        required: false
+        type: string
+
+env:
+  BASE_PATH: ${{ inputs.feature_path && format('feature/{0}/', inputs.feature_path) || '' }}
 
 jobs:
   deploy-dev:
@@ -51,7 +55,7 @@ jobs:
           # This is redundant but keeping for posterity
           JEKYLL_ENV: "production"
         run: |
-          bundle exec jekyll build --source ./src --baseurl ${{ inputs.deploy_path == 'main' && '' || format('/{0}', inputs.deploy_path) }}
+          bundle exec jekyll build --source ./src --baseurl ${{ env.BASE_PATH }}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -81,10 +85,17 @@ jobs:
       #       -Dsonar.qualitygate.wait=true
       #       -Dsonar.ci.autoconfig.disabled=true
 
-      - name: Deploy the site
-        # This $TARGET_BUCKET comes from the step above, cmsgov/cdap/actions/aws-params-env-action@main
+      - name: Deploy the site to root url/directory
+        if: ${{ !env.BASE_PATH }}
+        # This $TARGET_BUCKET comes from a previous step, cmsgov/cdap/actions/aws-params-env-action@main
         run: |
-          aws s3 sync _site/ s3://$TARGET_BUCKET/${{ inputs.deploy_path }}/ --delete
+          aws s3 sync _site/ s3://$TARGET_BUCKET/ --delete --exclude 'feature/*'
+
+      - name: Deploy the site to feature url/directory
+        if: ${{ env.BASE_PATH }}
+        # This $TARGET_BUCKET comes from a previous step, cmsgov/cdap/actions/aws-params-env-action@main
+        run: |
+          aws s3 sync _site/ s3://$TARGET_BUCKET/${{ env.BASE_PATH }} --delete
       
       - name: Invalidate Cloudfront cache
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ on:
   workflow_call:
     inputs:
       deploy_path:
+        default: "main"
         required: false
         type: string
 
@@ -50,7 +51,7 @@ jobs:
           # This is redundant but keeping for posterity
           JEKYLL_ENV: "production"
         run: |
-          bundle exec jekyll build --source ./src --baseurl ${{ inputs.deploy_path && format('/{0}', inputs.deploy_path) || ''}}
+          bundle exec jekyll build --source ./src --baseurl ${{ inputs.deploy_path == 'main' && '' || format('/{0}', inputs.deploy_path) }}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -25,7 +25,7 @@ jobs:
           params: |
             TARGET_BUCKET=/bcda/stage/static_site
 
-      - name: Download Dev Bucket
+      - name: Download Site from Staging Bucket
         run: |
           aws s3 sync s3://${TARGET_BUCKET}/ ./temp-site/ --exclude 'feature/*'
 
@@ -41,7 +41,7 @@ jobs:
           params: |
             TARGET_BUCKET=/bcda/prod/static_site
 
-      - name: Copy site to Prod Bucket
+      - name: Copy Site to Prod Bucket
         run: |
           aws s3 sync ./temp-site/ s3://${TARGET_BUCKET}/ --delete
 

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -2,15 +2,7 @@ name: "promote"
 
 on:
   workflow_dispatch:
-    inputs:
-      deploy_path:
-        description: "S3 directory deployment location (e.g. s3://s3_bucket/deploy_path/)"
-        default: "main"
   workflow_call:
-    inputs:
-      deploy_path:
-        required: false
-        type: string
 
 jobs:
   promote:
@@ -35,7 +27,7 @@ jobs:
 
       - name: Download Dev Bucket
         run: |
-          aws s3 sync s3://${TARGET_BUCKET}/${{ inputs.deploy_path }}/ ./temp-site/
+          aws s3 sync s3://${TARGET_BUCKET}/ ./temp-site/ --exclude 'feature/*'
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,7 +11,7 @@ jobs:
   deploy:
     if: ${{ !startsWith(github.actor, 'bot-') }}
     with:
-      deploy_path: ${{ github.event.number }}
+      feature_path: ${{ github.event.number }}
     uses: ./.github/workflows/deploy.yml
     secrets: inherit
 
@@ -29,6 +29,7 @@ jobs:
   broken-link-check:
     needs: deploy
     with:
-      deploy_path: ${{ github.event.number }}
+      env: staging
+      feature_path: ${{ github.event.number }}
     uses: ./.github/workflows/broken-link-check.yml
     secrets: inherit

--- a/.github/workflows/push-dev.yml
+++ b/.github/workflows/push-dev.yml
@@ -11,8 +11,6 @@ concurrency:
 
 jobs:
   deploy:
-    with:
-      deploy_path: "main"
     uses: ./.github/workflows/deploy.yml
     secrets: inherit
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,5 @@ on:
 
 jobs:
   deploy:
-    with:
-      deploy_path: "main"
     uses: ./.github/workflows/promote.yml
     secrets: inherit


### PR DESCRIPTION
## 🎫 Ticket


## 🛠 Changes

- updated the deploy workflow (and other workflows) to associate PR deployments with a subpath under `/feature/{PR#}`
- updated the deploy workflow (and other workflows) to associate deployments from main with the staging root path `/`

## ℹ️ Context for reviewers

Presently, when changes are merged to main, they are deployed to the url https://stage.bcda.cms.gov/main/. This paradigm adds some difficulty to the prod promotion process:
1. the base url of the main deployment in staging (`/main`) is different from that of prod (`/`), which means that for every promotion, and temporary change must be introduced tot he staging workflow to remove the base url
2. the exact build promoted to prod is _not_ identical to the build tested in staging, since the staging build must be reproduced in the above point, and that build has broken links due to the mismatch between the built base url and the deployed directory structure

This update ensures that merges to main are instead deployed to https://stage.bcda.cms.gov/, which keeps the base staging url up to date with changes that will go to prod, and makes deployment to prod easier since devs won't have to constantly make and remove similar changes to the deploy workflow. It also ensures that what is tested in staging is exactly what is deployed to prod.
Additionally, PR changes are deployed to `/feature/{PR#}` instead of `/{PR#}`, which makes it simple to exclude them from the prod promotion. When a staging deployment is promoted to prod, the immediate subdirectory `/feature` is ignored, enabling users to safely deploy feature branches to `/feature` while keeping it separate from anything that might be deployed to prod.

## ✅ Acceptance Validation

(How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable.)

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
