### PR TITLE
BCDA-10142 Use advanced credentials in sample code

### DIFF
--- a/src/_data/credentials.yml
+++ b/src/_data/credentials.yml
@@ -1,19 +1,3 @@
-sandbox:
-  extra_small:
-    client_id: "3841c594-a8c0-41e5-98cc-38bb45360d3c"
-    client_secret: "c29dd70cdb04dec2b8c06bc543e012f5264c57b13c523999aea29af76cf7f80fd90c864da6f8e7c6"
-  small:
-    client_id: "d5f83f74-6c55-4f1e-9d16-0022688171ba"
-    client_secret: "9158bb034b01be0c06d9794fe5fdcebab5f3edec6eddc5d6d8555cb0b4a6a8428b7cb34a429c5b63"
-  medium:
-    client_id: "8c75a6f6-02b9-4a47-96c1-0bd6efd4b5e3"
-    client_secret: "1e9a02a3fa703c6b818b11a1f675a1bbc3d71e7e25dccfce7e13c06a67633a6cc1093af9de899ba0"
-  large:
-    client_id: "f268a8c6-8a29-4d2b-8b92-263dc775750d"
-    client_secret: "18017706f885a6f8816a39ec4b77335bfc5e42d748f745ae0e4929c52be0cd87898278dec886157d"
-  extra_large:
-    client_id: "6152afb4-c555-46e4-93de-fa16a441d643"
-    client_secret: "f73a5b54c96601570f54d337fa399964399f7ae3b5223d62178cf415e60b93e799709b0fddea448a"
 adv:
   small:
     client_id: "6dc59a4c-ef93-46c0-9c00-02e500e13731"

--- a/src/_pages/api-documentation/get-a-bearer-token.md
+++ b/src/_pages/api-documentation/get-a-bearer-token.md
@@ -98,34 +98,11 @@ Now you can begin [accessing claims data]({{ '/api-documentation/access-claims-d
 
 Sandbox credentials allow anyone to access synthetic test claims data. These credentials will not work in the production environment. 
 
-Sample data sets vary in size and data complexity, ranging from 50 to 30,000 synthetic enrollees, to best match the needs of your model entity.  
-
-### Adjudicated claims data sets – 2 simple sizes
-Use the data sets to test retrieving and downloading data files into your internal ingestion processes. However, the test data may not reflect an accurate distribution of disease and demographic information.
-
-#### Extra-small model entity (50 synthetic enrollees)
-
-Client ID:
-
-{% include copy_snippet.html code=site.data.credentials.sandbox.extra_small.client_id language="yaml" can_copy=true %}
-
-Client secret:
-
-{% include copy_snippet.html code=site.data.credentials.sandbox.extra_small.client_secret language="yaml" can_copy=true %}
-
-#### Extra-large model entity (30,000 synthetic enrollees)
-
-Client ID:
-
-{% include copy_snippet.html code=site.data.credentials.sandbox.extra_large.client_id language="yaml" can_copy=true %}
-
-Client secret:
-
-{% include copy_snippet.html code=site.data.credentials.sandbox.extra_large.client_secret language="yaml" can_copy=true %}
+Sample data sets vary in size and data complexity, ranging from 100 to 11,000 synthetic enrollees, to best match the needs of your model entity.  
 
 ### Adjudicated claims data sets – 2 advanced sizes
 
-Advanced data sets offer a more accurate representation with the bulk FHIR format and a realistic distribution of disease and demographic information. 
+Advanced data sets offer an accurate representation with the bulk FHIR format and a realistic distribution of disease and demographic information. 
 
 The small data set helps you understand the format of BCDA data. The large data set is better for in-depth exploration or early load testing of your systems.
 

--- a/src/_pages/api-documentation/get-a-bearer-token.md
+++ b/src/_pages/api-documentation/get-a-bearer-token.md
@@ -27,17 +27,17 @@ BCDA protects its token endpoint with Basic Auth. Your credentials will be forma
     </div>
 </div>
 
-Start a request for a bearer token in your terminal window or using a tool such as Postman. The following example uses the credentials of the extra-small model entity in BCDA's sandbox environment:
+Start a request for a bearer token in your terminal window or using a tool such as Postman. The following example uses the credentials of the Small Advanced Model Entity in BCDA's sandbox environment:
 
 #### Sample Credentials
 
-Example client ID (Extra-Small Model Entities):
+Example client ID (Small Advanced Model Entity):
 
-{% include copy_snippet.html code=site.data.credentials.sandbox.extra_small.client_id language="yaml" can_copy=true %}
+{% include copy_snippet.html code=site.data.credentials.adv.small.client_id language="yaml" can_copy=true %}
 
-Example client secret (Extra-Small Model Entities):
+Example client secret (Small Advanced Model Entity):
 
-{% include copy_snippet.html code=site.data.credentials.sandbox.extra_small.client_secret language="yaml" can_copy=true %}
+{% include copy_snippet.html code=site.data.credentials.adv.small.client_secret language="yaml" can_copy=true %}
 
 #### Request header
 
@@ -57,7 +57,7 @@ This command uses curl's built-in ability to Base-64 encode your credential to r
 
 {% capture Snippet4 %}
 curl -d "" -X POST "https://sandbox.bcda.cms.gov/auth/token" \
-	--user {{site.data.credentials.sandbox.extra_small.client_id}}:{{site.data.credentials.sandbox.extra_small.client_secret}} \
+	--user {{site.data.credentials.adv.small.client_id}}:{{site.data.credentials.adv.small.client_secret}} \
 	-H "Accept: application/json"
 {% endcapture %}
 {% include copy_snippet.html code=Snippet4 language="shell" can_copy=true %}


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/10142

## 🛠 Changes

Update sample curl commands to use creds of a v3 entity
Remove credentials for "simple" and other unused data sets

## ℹ️ Context

In preparation for v3, we should have sandbox use v3 creds by default

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Validated in staging (right hand side) against prod (left hand side)
✅ sample credentials are correct
<img width="1512" height="599" alt="image" src="https://github.com/user-attachments/assets/174c8edf-0b1e-44a4-acf6-d48e3edd1190" />
✅ curl command uses the correct creds
<img width="1512" height="418" alt="image" src="https://github.com/user-attachments/assets/c07e4d11-b935-404e-9416-58ba72225c1b" />
✅ "simple" creds are removed
<img width="1510" height="872" alt="image" src="https://github.com/user-attachments/assets/851be386-af84-4e3f-a0ab-a7ac7f267587" />

