### PR TITLE
Update v3 eligibility for partially adjudicated claims

### DIFF
--- a/src/_pages/v3/partially-adjudicated-claims-data-v3.md
+++ b/src/_pages/v3/partially-adjudicated-claims-data-v3.md
@@ -59,15 +59,12 @@ Fully adjudicated claims offer the same rich insights, with some small differenc
     </tr>
     <tr scope="row">
       <td data-label="Partially adjudicated claims">
-        Available to <a
-          href="https://www.cms.gov/priorities/innovation/innovation-models/aco-reach"
+        Available to all <a href="{{ '/index.html#eligible-model-entities' | relative_url }}">eligible model
+          entities</a>, except <a
+          href="https://www.cms.gov/priorities/innovation/innovation-models/guide"
           target="_blank"
           rel="noopener noreferrer"
-        >ACO REACH</a> and <a
-          href="https://www.cms.gov/priorities/innovation/innovation-models/iota"
-          target="_blank"
-          rel="noopener noreferrer"
-        >IOTA</a> participants only
+        >GUIDE</a> participants
       </td>
       <td data-label="Fully adjudicated claims">
         Available to all <a href="{{ '/index.html#eligible-model-entities' | relative_url }}">eligible model


### PR DESCRIPTION
All models have access to partially adjudicated claims data in BCDA v3, except GUIDE

## 🎫 Ticket

## 🛠 Changes
Update v3 eligibility for partially adjudicated claims in the v3 page for partially adjudicated claims data

## ℹ️ Context
Customer reported issue during BCDA office hours on July 9

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation
Validated in staging: [Comparison: partially and fully adjudicated claims](https://stage.bcda.cms.gov/feature/369/v3/partially-adjudicated-claims-data-v3.html#comparison-partially-and-fully-adjudicated-claims-2)
<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->